### PR TITLE
Implement blank properly on all field objects

### DIFF
--- a/app/fields/appropriate_adult_field.rb
+++ b/app/fields/appropriate_adult_field.rb
@@ -18,4 +18,8 @@ class AppropriateAdultField
   def present?
     appropriate_adult.present?
   end
+
+  def blank?
+    !present?
+  end
 end

--- a/app/fields/date_field.rb
+++ b/app/fields/date_field.rb
@@ -17,6 +17,10 @@ class DateField
     [year, month, day].any? &:present?
   end
 
+  def blank?
+    !present?
+  end
+
   def value
     Date.new year.to_i, month.to_i, day.to_i rescue nil
   end

--- a/app/fields/solicitor_field.rb
+++ b/app/fields/solicitor_field.rb
@@ -26,4 +26,8 @@ class SolicitorField
       SolicitorField.new
     end
   end
+
+  def blank?
+    !present?
+  end
 end

--- a/spec/forms/fields/appropriate_adult_field_spec.rb
+++ b/spec/forms/fields/appropriate_adult_field_spec.rb
@@ -78,5 +78,23 @@ RSpec.describe AppropriateAdultField do
         end
       end
     end
+
+    context "blank?" do
+      context "no value specified" do
+        subject { AppropriateAdultField.new }
+
+        it "returns true" do
+          expect(subject).to be_blank
+        end
+      end
+
+      context "some fields" do
+        subject { AppropriateAdultField.new appropriate_adult: "yes" }
+
+        it "returns false" do
+          expect(subject).to_not be_blank
+        end
+      end
+    end
   end
 end

--- a/spec/forms/fields/date_field_spec.rb
+++ b/spec/forms/fields/date_field_spec.rb
@@ -89,6 +89,24 @@ RSpec.describe DateField do
         end
       end
     end
+
+    context "blank?" do
+      context "no fields filled in" do
+        subject { DateField.new }
+
+        it "returns true" do
+          expect(subject).to be_blank
+        end
+      end
+
+      context "some filled in" do
+        subject { DateField.new day: "I am filled in but not necessarily valid" }
+
+        it "returns false" do
+          expect(subject).to_not be_blank
+        end
+      end
+    end
   end
 
 end

--- a/spec/forms/fields/date_time_field_spec.rb
+++ b/spec/forms/fields/date_time_field_spec.rb
@@ -98,6 +98,24 @@ RSpec.describe DateTimeField do
         end
       end
     end
+
+    context "blank?" do
+      context "no fields filled in" do
+        subject { DateField.new }
+
+        it "returns true" do
+          expect(subject).to be_blank
+        end
+      end
+
+      context "some filled in" do
+        subject { DateField.new day: "I am filled in but not necessarily valid" }
+
+        it "returns false" do
+          expect(subject).to_not be_blank
+        end
+      end
+    end
   end
 
 end

--- a/spec/forms/fields/solicitor_field_spec.rb
+++ b/spec/forms/fields/solicitor_field_spec.rb
@@ -101,5 +101,23 @@ RSpec.describe SolicitorField do
         end
       end
     end
+
+    context "blank?" do
+      context "no fields" do
+        subject { SolicitorField.new }
+
+        it "returns true" do
+          expect(subject).to be_blank
+        end
+      end
+
+      context "some fields" do
+        subject { SolicitorField.new email: "I am not necessarily valid, but I am present" }
+
+        it "returns false" do
+          expect(subject).to_not be_blank
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes a bug where forms would fail to submit even
when there were no errors.

I know this isn't very DRY, but it will be in the mysterious `paradats` branch.