### PR TITLE
Fix unexpected role bug

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -7,6 +7,6 @@ class BaseController < ApplicationController
 
   private
   def user_not_authorized
-    render text: t('not_authorized'), status: 403
+    render file: 'public/403.html', :status => :not_found, :layout => false
   end
 end

--- a/app/policies/defence_request_policy.rb
+++ b/app/policies/defence_request_policy.rb
@@ -14,6 +14,8 @@ class DefenceRequestPolicy < ApplicationPolicy
         scope.not_draft
       elsif user.roles.include?("solicitor")
         scope.has_solicitor(user).accepted_or_aborted
+      else
+        scope.none
       end
     end
   end

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= t('not_authorized') %> (403)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/403.html -->
+  <div class="dialog">
+    <div>
+      <h1><%= t('not_authorized') %>.</h1>
+      <p></p>
+    </div>
+    <p>Please contact your administrator.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
If you sign in with a user that doesn't have the `cco`, `cso`, or `solicitor` role, the system currently returns `nil` from `policy_scope`, which then can't have further scopes chained onto it.

This PR fixes this bug, and merely returns and empty relation instead.
It also adds a temporarily nicer looking 403 page based on the standard 404 page.