### PR TITLE
[fix_all_single_quotes] Double quote everything

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -100,12 +100,6 @@ Style/SpaceInsideBrackets:
 Style/SpaceInsideParens:
   Enabled: false
 
-# Offense count: 225
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 4
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path("../config/application", __FILE__)
 
 Rails.application.load_tasks

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -8,6 +8,6 @@ class BaseController < ApplicationController
   private
 
   def user_not_authorized
-    render file: 'public/403.html', :status => :not_found, :layout => false
+    render file: "public/403.html", :status => :not_found, :layout => false
   end
 end

--- a/app/controllers/defence_requests_controller.rb
+++ b/app/controllers/defence_requests_controller.rb
@@ -45,8 +45,8 @@ class DefenceRequestsController < BaseController
 
     # Below is evil, this is a quick hack to search for solicitors and firms in the same box until we figure out how
     # we should do it properly, probably with a proper search endpoint on the api using postgres full text search.
-    solicitors = search_json['solicitors'].map { |s| s.tap { |t| t['firm_name'] = t['firm']['name']; t.delete 'firm'} }
-    firm_solicitors = search_json['firms'].map {|f| f['solicitors'].map { |s| s.tap { |t| t['firm_name'] = f['name'] } } }.flatten
+    solicitors = search_json["solicitors"].map { |s| s.tap { |t| t["firm_name"] = t["firm"]["name"]; t.delete "firm"} }
+    firm_solicitors = search_json["firms"].map {|f| f["solicitors"].map { |s| s.tap { |t| t["firm_name"] = f["name"] } } }.flatten
     @solicitors = (firm_solicitors + solicitors).uniq
   end
 
@@ -110,7 +110,7 @@ class DefenceRequestsController < BaseController
   end
 
   def update_and_accept?
-    params[:commit] == 'Update and Accept'
+    params[:commit] == "Update and Accept"
   end
 
   def solicitor_details_missing?

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,22 +2,22 @@ class StaticController < ApplicationController
   protect_from_forgery except: :expired
 
   def help
-    render 'help'
+    render "help"
   end
 
   def accessibility
-    render 'accessibility'
+    render "accessibility"
   end
 
   def cookies
-    render 'cookies'
+    render "cookies"
   end
 
   def expired
-    render 'expired'
+    render "expired"
   end
 
   def terms
-    render 'terms'
+    render "terms"
   end
 end

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -4,7 +4,7 @@ class StatusController < ApplicationController
   def index
     respond_to do |format|
       format.json { render json: {"status" => "OK"} }
-      format.xml { render xml: {"Status" => "OK"}.to_xml(root: 'Response') }
+      format.xml { render xml: {"Status" => "OK"}.to_xml(root: "Response") }
       format.any { render text: "OK"}
     end
   end

--- a/app/forms/defence_request_form.rb
+++ b/app/forms/defence_request_form.rb
@@ -16,7 +16,7 @@ class DefenceRequestForm
   end
 
   def self.model_name
-    ActiveModel::Name.new(self, nil, 'DefenceRequest')
+    ActiveModel::Name.new(self, nil, "DefenceRequest")
   end
 
   def initialize(defence_request)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,15 +29,15 @@ module ApplicationHelper
   end
 
   def js_partial
-    params[:controller] + '/js_partials/' + params[:controller] + '_' + params[:action] + '_js.html.erb'
+    params[:controller] + "/js_partials/" + params[:controller] + "_" + params[:action] + "_js.html.erb"
   end
 
   def date_formatter(date)
-    date ? date.strftime("%-d %B %Y") : ''
+    date ? date.strftime("%-d %B %Y") : ""
   end
 
   def date_and_time_formatter(date)
-    date ? date.strftime("%-d %B %Y - %R") : ''
+    date ? date.strftime("%-d %B %Y - %R") : ""
   end
 
   def boolean_formatter(val)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
-  layout 'mailer'
+  layout "mailer"
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -4,18 +4,18 @@ class Mailer < ApplicationMailer
   def notify_interview_start_change(defence_request, solicitor)
     @defence_request = defence_request
     mail(to: solicitor.email,
-         subject: t('interview_start_time_change'),
-         content_type: 'text/html',
-         importance: 'High'
+         subject: t("interview_start_time_change"),
+         content_type: "text/html",
+         importance: "High"
         )
   end
 
   def send_solicitor_case_details(defence_request, solicitor)
     @defence_request = defence_request
     mail(to: solicitor.email,
-         subject: t('case_details'),
-         content_type: 'text/html',
-         importance: 'High'
+         subject: t("case_details"),
+         content_type: "text/html",
+         importance: "High"
     )
   end
 end

--- a/app/models/defence_request.rb
+++ b/app/models/defence_request.rb
@@ -106,7 +106,7 @@ class DefenceRequest < ActiveRecord::Base
   private
 
   def format_phone_number(phone_number)
-    phone_number.to_s.gsub(/\D/, '') if phone_number
+    phone_number.to_s.gsub(/\D/, "") if phone_number
   end
 
   def notify_interview_start_change

--- a/app/models/dscc_number_generator.rb
+++ b/app/models/dscc_number_generator.rb
@@ -38,7 +38,7 @@ class DsccNumberGenerator
     loop do
       result = try_generate next_suffix
 
-      break if suffixes.empty? || result.first['dscc_number']
+      break if suffixes.empty? || result.first["dscc_number"]
     end
 
     result.first.symbolize_keys if result.first
@@ -61,11 +61,11 @@ class DsccNumberGenerator
   end
 
   def prefix
-    created_at.strftime('%y%m')
+    created_at.strftime("%y%m")
   end
 
   def previous_month_prefix
-    (created_at - 1.month).strftime('%y%m')
+    (created_at - 1.month).strftime("%y%m")
   end
 
   def next_suffix

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+load Gem.bin_path("bundler", "bundle")

--- a/bin/rails
+++ b/bin/rails
@@ -3,6 +3,6 @@ begin
   load File.expand_path("../spring", __FILE__)
 rescue LoadError
 end
-APP_PATH = File.expand_path('../../config/application', __FILE__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../../config/application", __FILE__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -3,6 +3,6 @@ begin
   load File.expand_path("../spring", __FILE__)
 rescue LoadError
 end
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require 'pathname'
+require "pathname"
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+APP_ROOT = Pathname.new File.expand_path("../../",  __FILE__)
 
 Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../boot', __FILE__)
+require File.expand_path("../boot", __FILE__)
 
 # Pick the frameworks you want:
 require "active_model/railtie"
@@ -38,21 +38,21 @@ module DefenceSolicitor
       generate.view_specs false
     end
 
-    config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT'] || ''
+    config.relative_url_root = ENV["RAILS_RELATIVE_URL_ROOT"] || ""
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
     config.use_govuk_elements_form_builder = false
     # app title appears in the header bar
-    config.proposition_title = 'Defence Solicitor Deployment Service'
+    config.proposition_title = "Defence Solicitor Deployment Service"
     # phase governs text indicators and highlight colours
     # presumed values: alpha, beta, live
-    config.phase = 'alpha'
+    config.phase = "alpha"
     # product type may also govern highlight colours
     # known values: information, service
-    config.product_type = 'service'
+    config.product_type = "service"
     # Feedback URL (URL for feedback link in phase banner)
     # Use 'auto_add_path' for it to add a path link to the new_feedback route
-    config.feedback_url = config.relative_url_root + '/feedback/new'
+    config.feedback_url = config.relative_url_root + "/feedback/new"
 
     config.action_mailer.default_url_options = Settings.action_mailer.default_url_options.to_h
     config.action_mailer.smtp_settings = Settings.action_mailer.smtp_settings.to_h

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,11 +1,11 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'rails/commands/server'
+require "bundler/setup" # Set up gems listed in the Gemfile.
+require "rails/commands/server"
 
 # Import environment variables when dotenv is available
-if Gem::Specification.find_all_by_name('dotenv').any?
-  require 'dotenv/rails-now'
+if Gem::Specification.find_all_by_name("dotenv").any?
+  require "dotenv/rails-now"
   Dotenv::Railtie.load
 end
 
@@ -13,7 +13,7 @@ module Rails
   class Server
     alias :default_options_alias :default_options
     def default_options
-      port = ENV.fetch("SERVER_PORT") { '3000' }
+      port = ENV.fetch("SERVER_PORT") { "3000" }
       default_options_alias.merge!(Port: port)
     end
   end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require File.expand_path('../application', __FILE__)
+require File.expand_path("../application", __FILE__)
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.serve_static_files = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Configure static file server for tests with Cache-Control for performance.
   config.serve_static_files   = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/config/initializers/metrics.rb
+++ b/config/initializers/metrics.rb
@@ -29,8 +29,8 @@ ActiveSupport::Notifications.subscribe "process_action.action_controller" do |na
   METRICS.increment "controller.method.#{payload[:method].downcase}"
   METRICS.increment "controller.#{payload[:controller].downcase}.#{payload[:action].downcase}"
 
-  METRICS.timing 'controller.view.total_render_time', payload[:view_runtime], 1
-  METRICS.timing 'controller.db.total_query_time', payload[:db_runtime], 1
+  METRICS.timing "controller.view.total_render_time", payload[:view_runtime], 1
+  METRICS.timing "controller.db.total_query_time", payload[:db_runtime], 1
 
 end
 
@@ -57,19 +57,19 @@ ActiveSupport::Notifications.subscribe "sql.active_record" do |name, start, fini
   case payload[:sql]
   when /^SELECT/
     payload[:sql] =~ SELECT_DELETE
-    METRICS.increment('sql.select')
+    METRICS.increment("sql.select")
     METRICS.timing("sql.#{$1}.select.query_time", (finish - start) * 1000, 1)
   when /^DELETE/
     payload[:sql] =~ SELECT_DELETE
-    METRICS.increment('sql.delete')
+    METRICS.increment("sql.delete")
     METRICS.timing("sql.#{$1}.delete.query_time", (finish - start) * 1000, 1)
   when /^INSERT/
     payload[:sql] =~ INSERT
-    METRICS.increment('sql.insert')
+    METRICS.increment("sql.insert")
     METRICS.timing("sql.#{$1}.insert.query_time", (finish - start) * 1000, 1)
   when /^UPDATE/
     payload[:sql] =~ UPDATE
-    METRICS.increment('sql.update')
+    METRICS.increment("sql.update")
     METRICS.timing("sql.#{$1}.update.query_time", (finish - start) * 1000, 1)
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_defence-solicitor_session'
+Rails.application.config.session_store :cookie_store, key: "_defence-solicitor_session"

--- a/db/migrate/20150202171948_install_audited.rb
+++ b/db/migrate/20150202171948_install_audited.rb
@@ -17,9 +17,9 @@ class InstallAudited < ActiveRecord::Migration
       t.column :created_at, :datetime
     end
 
-    add_index :audits, [:auditable_id, :auditable_type], :name => 'auditable_index'
-    add_index :audits, [:associated_id, :associated_type], :name => 'associated_index'
-    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, [:auditable_id, :auditable_type], :name => "auditable_index"
+    add_index :audits, [:associated_id, :associated_type], :name => "associated_index"
+    add_index :audits, [:user_id, :user_type], :name => "user_index"
     add_index :audits, :request_uuid
     add_index :audits, :created_at
   end

--- a/db/migrate/20150317151004_rename_open_state_to_acknowledged.rb
+++ b/db/migrate/20150317151004_rename_open_state_to_acknowledged.rb
@@ -1,6 +1,6 @@
 class RenameOpenStateToAcknowledged < ActiveRecord::Migration
   class DummyDefenseRequest < ActiveRecord::Base
-    self.table_name = 'defence_requests'
+    self.table_name = "defence_requests"
   end
 
   def up

--- a/deploy/before_restart
+++ b/deploy/before_restart
@@ -5,20 +5,20 @@ def run(cmd)
   exit($?.exitstatus) unless system "umask 002 && #{cmd}"
 end
 
-RAILS_ENV   = ENV['RAILS_ENV'] || 'production'
-use_bundler = File.file? 'Gemfile'
-rake_cmd    = use_bundler ? 'bundle exec rake' : 'rake'
+RAILS_ENV   = ENV["RAILS_ENV"] || "production"
+use_bundler = File.file? "Gemfile"
+rake_cmd    = use_bundler ? "bundle exec rake" : "rake"
 
 if use_bundler
-  bundler_args = ['--deployment']
-  BUNDLE_WITHOUT = ENV['BUNDLE_WITHOUT'] || 'development:test'
-  bundler_args << '--without' << BUNDLE_WITHOUT unless BUNDLE_WITHOUT.empty?
+  bundler_args = ["--deployment"]
+  BUNDLE_WITHOUT = ENV["BUNDLE_WITHOUT"] || "development:test"
+  bundler_args << "--without" << BUNDLE_WITHOUT unless BUNDLE_WITHOUT.empty?
 
   # update gem bundle
   run "bundle install #{bundler_args.join(' ')}"
 end
 
-if File.file? 'Rakefile'
+if File.file? "Rakefile"
   tasks = []
 
   num_migrations = `git diff #{oldrev} #{newrev} --diff-filter=A --name-only -z db/migrate`.split("\0").size

--- a/lib/tasks/spec_and_rubocop.rake
+++ b/lib/tasks/spec_and_rubocop.rake
@@ -1,5 +1,5 @@
 if Rails.env.development? || Rails.env.test?
-  require 'rubocop/rake_task'
+  require "rubocop/rake_task"
 
   RuboCop::RakeTask.new(:rubocop)
   task default: :rubocop

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -1,37 +1,37 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe StatusController, type: :controller do
 
   describe "GET index" do
-    it 'returns 200 status code' do
+    it "returns 200 status code" do
       get :index
       expect(response).to have_http_status(:ok)
     end
 
-    context 'HTML request' do
-      it 'returns OK in body' do
+    context "HTML request" do
+      it "returns OK in body" do
         get :index
         expect(response.body).to include("OK")
       end
     end
 
-    context 'JSON request' do
+    context "JSON request" do
       it 'returns a JSON status "OK"' do
-        get :index, format: 'json'
+        get :index, format: "json"
         expect(JSON.parse response.body.strip).to eq({"status" => "OK"})
       end
     end
 
-    context 'XML request' do
+    context "XML request" do
       it 'returns a XML status "OK"' do
-        get :index, format: 'xml'
+        get :index, format: "xml"
         expect(response.body.strip).to eq("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Status>OK</Status>\n</Response>")
       end
     end
 
-    context 'other MIME type' do
-      it 'returns OK in body' do
-        get :index, format: 'text'
+    context "other MIME type" do
+      it "returns OK in body" do
+        get :index, format: "text"
         expect(response.body).to include("OK")
       end
     end

--- a/spec/factories/defence_request.rb
+++ b/spec/factories/defence_request.rb
@@ -13,17 +13,17 @@ FactoryGirl.define do
   end
 
   factory :defence_request, aliases: [:own_solicitor] do
-    solicitor_type 'own'
+    solicitor_type "own"
     sequence(:solicitor_name) { |n| "solicitor_name-#{n}" }
     sequence(:solicitor_firm) { |n| "solicitor_firm-#{n}" }
     scheme 1
-    phone_number '447810480123'
+    phone_number "447810480123"
     sequence(:detainee_name) { |n| "detainee_name-#{n}" }
-    gender 'male'
+    gender "male"
     date_of_birth twenty_one_years_ago
     detainee_age 21
     sequence(:custody_number) { |n| "custody_number-#{n}" }
-    offences 'Theft'
+    offences "Theft"
     time_of_arrival now
     sequence(:comments) { |n| "commenty-comments-are here: #{n}" }
     adult [nil, true, false].sample
@@ -32,23 +32,23 @@ FactoryGirl.define do
   end
 
   trait :duty_solicitor do
-    solicitor_type 'duty'
+    solicitor_type "duty"
     solicitor_name nil
     solicitor_firm nil
-    scheme 'No Scheme'
-    phone_number ''
+    scheme "No Scheme"
+    phone_number ""
   end
 
   trait :draft do
-    state 'draft'
+    state "draft"
   end
 
   trait :queued do
-    state 'queued'
+    state "queued"
   end
 
   trait :acknowledged do
-    state 'acknowledged'
+    state "acknowledged"
     association :cco, factory: :cco_user
   end
 
@@ -61,24 +61,24 @@ FactoryGirl.define do
   end
 
   trait :accepted do
-    state 'accepted'
+    state "accepted"
     dscc_number &generate_dscc_number
     association :solicitor, factory: :solicitor_user
   end
 
   trait :aborted do
     dscc_number &generate_dscc_number
-    reason_aborted 'This has been closed for a reason.'
-    state 'aborted'
+    reason_aborted "This has been closed for a reason."
+    state "aborted"
   end
 
   trait :finished do
-    state 'finished'
+    state "finished"
   end
 
   trait :appropriate_adult do
     appropriate_adult true
-    appropriate_adult_reason 'They look underage'
+    appropriate_adult_reason "They look underage"
   end
 
   trait :interview_start_time do
@@ -122,7 +122,7 @@ FactoryGirl.define do
 
   trait :unfit_for_interview do
     fit_for_interview false
-    unfit_for_interview_reason 'Drunk as a skunk'
+    unfit_for_interview_reason "Drunk as a skunk"
   end
 
   trait :with_interpreter_required do

--- a/spec/features/solicitor/view_firms_requests_spec.rb
+++ b/spec/features/solicitor/view_firms_requests_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Solicitors viewing their firm's requests" do
         :aborted,
         solicitor_uid: nil,
         organisation_uid: solicitor.organisation_uids.first,
-        offences: 'Arson'
+        offences: "Arson"
     )
     other_firms_defence_request =
       create(
@@ -18,7 +18,7 @@ RSpec.feature "Solicitors viewing their firm's requests" do
         :aborted,
         solicitor_uid: nil,
         organisation_uid: another_solicitor.organisation_uids.first,
-        offences: 'Extortion'
+        offences: "Extortion"
     )
 
     login_with solicitor

--- a/spec/forms/defence_request_form_spec.rb
+++ b/spec/forms/defence_request_form_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DefenceRequestForm do
 
@@ -30,9 +30,9 @@ RSpec.describe DefenceRequestForm do
 
     context "with invalid params" do
       context "invalid attribute on the dr" do
-        let(:invalid_params) { params_for_dr.merge({ solicitor_name: '' }) }
+        let(:invalid_params) { params_for_dr.merge({ solicitor_name: "" }) }
 
-        it 'adds any errors from the dr, to itself' do
+        it "adds any errors from the dr, to itself" do
           expect(subject.submit invalid_params).to eql false
           expect(subject.errors.count).to eql 1
           expect(subject.errors[:solicitor_name]).to eql ["can't be blank"]
@@ -43,14 +43,14 @@ RSpec.describe DefenceRequestForm do
         context "that is has presence validated on the dr" do
           let(:invalid_params) { params_for_dr.merge({ time_of_arrival: invalid_time_of_arrival }) }
           context "blank" do
-            let(:invalid_time_of_arrival) { { year: '',
-                                              month: '',
-                                              day: '',
-                                              hour: '',
-                                              min: '' } }
+            let(:invalid_time_of_arrival) { { year: "",
+                                              month: "",
+                                              day: "",
+                                              hour: "",
+                                              min: "" } }
 
 
-            it 'adds errors from the field object to itself' do
+            it "adds errors from the field object to itself" do
               expect(subject.submit invalid_params).to eql false
               expect(subject.errors.count).to eql 1
               expect(subject.errors[:time_of_arrival]).to eql ["can't be blank"]
@@ -58,11 +58,11 @@ RSpec.describe DefenceRequestForm do
           end
 
           context "not blank" do
-            let(:invalid_time_of_arrival) { { year: 'I',
-                                              month: 'AM',
-                                              day: 'TOTALLY',
-                                              hour: 'BROKEN',
-                                              min: '!' } }
+            let(:invalid_time_of_arrival) { { year: "I",
+                                              month: "AM",
+                                              day: "TOTALLY",
+                                              hour: "BROKEN",
+                                              min: "!" } }
             it "adds errors from the field object to itself" do
               expect(subject.submit invalid_params).to eql false
               expect(subject.errors.count).to eql 1
@@ -80,27 +80,27 @@ RSpec.describe DefenceRequestForm do
           let(:invalid_params) { params_for_dr.merge({ interview_start_time: invalid_interview_start_time }) }
 
           context "blank" do
-            let(:invalid_interview_start_time) { { year: '',
-                                                   month: '',
-                                                   day: '',
-                                                   hour: '',
-                                                   min: '' } }
+            let(:invalid_interview_start_time) { { year: "",
+                                                   month: "",
+                                                   day: "",
+                                                   hour: "",
+                                                   min: "" } }
 
 
-            it 'it does not add any errors to itself' do
+            it "it does not add any errors to itself" do
               expect(subject.submit invalid_params).to eql true
               expect(subject.errors.count).to eql 0
             end
           end
 
           context "not blank" do
-            let(:invalid_interview_start_time) { { year: 'I',
-                                                   month: 'AM',
-                                                   day: 'REAAAALLY',
-                                                   hour: 'BROKEN',
-                                                   min: '!' } }
+            let(:invalid_interview_start_time) { { year: "I",
+                                                   month: "AM",
+                                                   day: "REAAAALLY",
+                                                   hour: "BROKEN",
+                                                   min: "!" } }
 
-            it 'adds errors from the field object to itself' do
+            it "adds errors from the field object to itself" do
               expect(subject.submit invalid_params).to eql false
               expect(subject.errors.count).to eql 1
               expect(subject.errors[:interview_start_time]).to eql [["Invalid Date or Time",

--- a/spec/forms/fields/date_field_spec.rb
+++ b/spec/forms/fields/date_field_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DateField do
 

--- a/spec/forms/fields/date_time_field_spec.rb
+++ b/spec/forms/fields/date_time_field_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DateTimeField do
 

--- a/spec/forms/fields/solicitor_field_spec.rb
+++ b/spec/forms/fields/solicitor_field_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe SolicitorField do
 

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -2,30 +2,30 @@ require "rails_helper"
 
 RSpec.describe Mailer, type: :mailer do
   subject { Mailer }
-  let(:defence_request) { FactoryGirl.create(:defence_request, interview_start_time: DateTime.parse('13-04-1992 9:50')) }
+  let(:defence_request) { FactoryGirl.create(:defence_request, interview_start_time: DateTime.parse("13-04-1992 9:50")) }
   let(:solicitor) { FactoryGirl.create(:solicitor_user) }
 
-  describe 'notify_interview_start_change' do
+  describe "notify_interview_start_change" do
     before do
       @response = subject.notify_interview_start_change(defence_request, solicitor).deliver_now
     end
 
-    it 'contains a link to the request' do
-      expect(@response.body).to have_link 'View the case details'
+    it "contains a link to the request" do
+      expect(@response.body).to have_link "View the case details"
     end
 
-    it 'contains the new start time' do
-      expect(@response.body).to have_content '9:50'
+    it "contains the new start time" do
+      expect(@response.body).to have_content "9:50"
     end
   end
 
-  describe 'send_solicitor_case_details' do
+  describe "send_solicitor_case_details" do
     before do
       @response = subject.send_solicitor_case_details(defence_request, solicitor).deliver_now
     end
 
-    it 'contains a link to the request' do
-      expect(@response.body).to have_link 'View the case details'
+    it "contains a link to the request" do
+      expect(@response.body).to have_link "View the case details"
       expect(@response.body).to have_content defence_request.dscc_number
     end
   end

--- a/spec/models/defence_request_dscc_number_spec.rb
+++ b/spec/models/defence_request_dscc_number_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DefenceRequest, "#generate_dscc_number!" do
 

--- a/spec/models/defence_request_spec.rb
+++ b/spec/models/defence_request_spec.rb
@@ -1,7 +1,7 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DefenceRequest, type: :model do
-  describe 'validations' do
+  describe "validations" do
 
     it { expect(subject).to validate_presence_of :gender }
     it { expect(subject).to validate_presence_of :detainee_age }
@@ -10,7 +10,7 @@ RSpec.describe DefenceRequest, type: :model do
     it { expect(subject).to validate_presence_of :offences }
     it { expect(subject).to validate_numericality_of :detainee_age }
 
-    context 'own solicitor' do
+    context "own solicitor" do
       before do
         subject.solicitor_type = "own"
       end
@@ -20,7 +20,7 @@ RSpec.describe DefenceRequest, type: :model do
       it { expect(subject).to_not validate_presence_of :scheme }
     end
 
-    context 'duty solicitor' do
+    context "duty solicitor" do
       before do
         subject.solicitor_type = "duty"
       end
@@ -30,42 +30,42 @@ RSpec.describe DefenceRequest, type: :model do
       it { expect(subject).to_not validate_presence_of :phone_number }
     end
 
-    context 'appropriate_adult_reason required' do
+    context "appropriate_adult_reason required" do
       before do
         subject.appropriate_adult = true
       end
       it { expect(subject).to validate_presence_of :appropriate_adult_reason }
     end
 
-    context 'appropriate_adult_reason not required' do
+    context "appropriate_adult_reason not required" do
       before do
         subject.appropriate_adult = false
       end
       it { expect(subject).to_not validate_presence_of :appropriate_adult_reason }
     end
 
-    context 'unfit_for_interview_reason required' do
+    context "unfit_for_interview_reason required" do
       before do
         subject.fit_for_interview = false
       end
       it { expect(subject).to validate_presence_of :unfit_for_interview_reason }
     end
 
-    context 'unfit_for_interview_reason not required' do
+    context "unfit_for_interview_reason not required" do
       before do
         subject.fit_for_interview = true
       end
       it { expect(subject).to_not validate_presence_of :unfit_for_interview_reason }
     end
 
-    context 'interpreter_type required' do
+    context "interpreter_type required" do
       before do
         subject.interpreter_required = true
       end
       it { expect(subject).to validate_presence_of :interpreter_type }
     end
 
-    context 'interpreter_type not required' do
+    context "interpreter_type not required" do
       before do
         subject.interpreter_required = false
       end
@@ -73,79 +73,79 @@ RSpec.describe DefenceRequest, type: :model do
     end
   end
 
-  describe 'states' do
+  describe "states" do
 
-    it 'allows for correct transitions' do
+    it "allows for correct transitions" do
       expect(DefenceRequest.available_states).to eq [:aborted, :accepted, :acknowledged, :draft, :finished, :queued]
       expect(DefenceRequest.available_events).to eq [:abort, :accept, :acknowledge, :finish, :queue]
     end
 
-    shared_examples 'transition possible' do |event|
+    shared_examples "transition possible" do |event|
       specify { expect{ subject.send(event) }.to_not raise_error }
       specify { expect( subject.send("can_execute_#{event}?".to_sym) ).to eq true }
     end
 
-    shared_examples 'transition impossible' do |event|
+    shared_examples "transition impossible" do |event|
       specify { expect( subject.send("can_execute_#{event}?".to_sym) ).to eq false }
     end
 
-    shared_examples 'allowed transitions' do |allowed_events|
+    shared_examples "allowed transitions" do |allowed_events|
       specify { expect(subject.current_state).to eql state }
 
-      describe 'possible transitions' do
-        allowed_events.each { |e| it_behaves_like 'transition possible', e }
+      describe "possible transitions" do
+        allowed_events.each { |e| it_behaves_like "transition possible", e }
       end
 
-      describe 'impossible transitions' do
+      describe "impossible transitions" do
         disallowed_events = (DefenceRequest.available_events - allowed_events)
-        disallowed_events.each { |e| it_behaves_like 'transition impossible', e }
+        disallowed_events.each { |e| it_behaves_like "transition impossible", e }
       end
     end
 
     subject { FactoryGirl.create(:defence_request, state) }
 
-    describe 'draft' do
+    describe "draft" do
       let(:state) { :draft }
-      include_examples 'allowed transitions', [ :queue ]
+      include_examples "allowed transitions", [ :queue ]
     end
 
-    describe 'queued' do
+    describe "queued" do
       let(:state) { :queued }
-      include_examples 'allowed transitions', [ :acknowledge, :abort ]
+      include_examples "allowed transitions", [ :acknowledge, :abort ]
     end
 
-    describe 'acknowledged' do
+    describe "acknowledged" do
       subject { FactoryGirl.create(:defence_request, :acknowledged) }
 
       let(:state) { :acknowledged }
-      include_examples 'allowed transitions', [:finish, :abort ]
+      include_examples "allowed transitions", [:finish, :abort ]
     end
 
-    describe 'acknowledged with dscc_number' do
+    describe "acknowledged with dscc_number" do
       subject { FactoryGirl.create(:defence_request, :acknowledged, :with_dscc_number) }
 
       let(:state) { :acknowledged }
-      include_examples 'allowed transitions', [ :accept, :finish, :abort ]
+      include_examples "allowed transitions", [ :accept, :finish, :abort ]
     end
 
-    describe 'accepted' do
+    describe "accepted" do
       let(:state) { :accepted }
-      include_examples 'allowed transitions', [ :finish, :abort ]
+      include_examples "allowed transitions", [ :finish, :abort ]
     end
 
-    describe 'finished' do
+    describe "finished" do
       let(:state) { :finished }
-      include_examples 'allowed transitions', []
+      include_examples "allowed transitions", []
     end
   end
 
-  describe 'callbacks' do
-    context 'marked as accepted' do
+  describe "callbacks" do
+    context "marked as accepted" do
       before do
         @dr_with_dscc = FactoryGirl.create(:defence_request, :with_dscc_number, :acknowledged)
       end
 
-      it 'notifies the solicitor'  do
+      it "notifies the solicitor"  do
         expect(@dr_with_dscc).to receive(:send_solicitor_case_details).and_call_original
         @dr_with_dscc.accept
       end
@@ -155,17 +155,17 @@ RSpec.describe DefenceRequest, type: :model do
       @persisted_request = FactoryGirl.create(:defence_request)
     end
 
-    context 'interview time changes' do
-      it 'notifies the solicitor'  do
+    context "interview time changes" do
+      it "notifies the solicitor"  do
         expect(@persisted_request).to receive(:notify_interview_start_change).and_call_original
-        @persisted_request.update_attribute(:interview_start_time, DateTime.parse('13-04-1992 9:50'))
+        @persisted_request.update_attribute(:interview_start_time, DateTime.parse("13-04-1992 9:50"))
       end
     end
 
-    context 'save happens without change' do
-      it 'does not notify the solicitor' do
+    context "save happens without change" do
+      it "does not notify the solicitor" do
         expect(@persisted_request).to_not receive(:notify_interview_start_change)
-        @persisted_request.update_attribute(:detainee_name, 'Eamonn Holmes')
+        @persisted_request.update_attribute(:detainee_name, "Eamonn Holmes")
       end
     end
   end

--- a/spec/policies/defence_request_policy_spec.rb
+++ b/spec/policies/defence_request_policy_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DefenceRequestPolicy do
   subject { DefenceRequestPolicy.new user, defreq }

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -20,6 +20,6 @@ module SessionHelpers
   end
 
   def sign_out
-    click_link('Sign out')
+    click_link("Sign out")
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -2,45 +2,45 @@ module HelperMethods
 
   def create_a_defence_request
     visit new_defence_request_path
-    within '.new_defence_request' do
-      choose 'Own'
-      within '.details' do
-        fill_in 'Solicitor Name', with: 'Bob Smith'
-        fill_in 'Solicitor Firm', with: 'Acme Solicitors'
-        fill_in 'Phone Number', with: '0207 284 0000'
-        fill_in 'Custody Number', with: '#CUST-01234'
-        fill_in 'Offences', with: 'BadMurder'
-        select('09', from: 'defence_request_time_of_arrival_4i')
-        select('30', from: 'defence_request_time_of_arrival_5i')
+    within ".new_defence_request" do
+      choose "Own"
+      within ".details" do
+        fill_in "Solicitor Name", with: "Bob Smith"
+        fill_in "Solicitor Firm", with: "Acme Solicitors"
+        fill_in "Phone Number", with: "0207 284 0000"
+        fill_in "Custody Number", with: "#CUST-01234"
+        fill_in "Offences", with: "BadMurder"
+        select("09", from: "defence_request_time_of_arrival_4i")
+        select("30", from: "defence_request_time_of_arrival_5i")
       end
 
-      within '.detainee' do
-        fill_in 'Detainee Surname', with: 'Mannie'
-        fill_in 'Detainee First Name', with: 'Badder'
-        choose 'Male'
-        check 'defence_request[adult]'
-        select('1976', from: 'defence_request_date_of_birth_1i')
-        select('January', from: 'defence_request_date_of_birth_2i')
-        select('1', from: 'defence_request_date_of_birth_3i')
-        check 'defence_request[appropriate_adult]'
+      within ".detainee" do
+        fill_in "Detainee Surname", with: "Mannie"
+        fill_in "Detainee First Name", with: "Badder"
+        choose "Male"
+        check "defence_request[adult]"
+        select("1976", from: "defence_request_date_of_birth_1i")
+        select("January", from: "defence_request_date_of_birth_2i")
+        select("1", from: "defence_request_date_of_birth_3i")
+        check "defence_request[appropriate_adult]"
       end
-      fill_in 'Comments', with: 'This is a very bad man. Send him down...'
-      click_button 'Create Defence Request'
+      fill_in "Comments", with: "This is a very bad man. Send him down..."
+      click_button "Create Defence Request"
     end
   end
 
   def date_then_as_hash
     date = Time.at(1423757676).to_datetime
-    { 'day' => date.day, 'month' => date.month, 'year' => date.year, 'min' => date.minute, 'hour' => date.hour }
+    { "day" => date.day, "month" => date.month, "year" => date.year, "min" => date.minute, "hour" => date.hour }
   end
 
   def date_now_as_hash
     date = DateTime.current
-    { 'day' => date.day, 'month' => date.month, 'year' => date.year, 'min' => date.minute, 'hour' => date.hour }
+    { "day" => date.day, "month" => date.month, "year" => date.year, "min" => date.minute, "hour" => date.hour }
   end
 
   def twenty_one_years_ago_as_hash
     date = DateTime.current - 21.years
-    { 'day' => date.day, 'month' => date.month, 'year' => date.year }
+    { "day" => date.day, "month" => date.month, "year" => date.year }
   end
 end

--- a/spec/support/pundit_matcher.rb
+++ b/spec/support/pundit_matcher.rb
@@ -46,12 +46,12 @@ RSpec::Matchers.define :permit_actions_and_forbid_all_others do |permitted_actio
     permitted_message = if !failed_permitted.empty?
                           ["Expected actions to be permitted:", failed_permitted].join "\n"
                         else
-                          ''
+                          ""
                         end
     disallowed_message = if !failed_forbidden.empty?
                            ["Expected actions to be forbidden:", failed_forbidden].join "\n"
                          else
-                           ''
+                           ""
                          end
     [permitted_message, disallowed_message].join "\n"*2
   end


### PR DESCRIPTION
Change all single quoted strings to double quotes, so that the codebase matches our coding standard.

Note that I've changed standard rails components in config/* and bin/*
etc. The reasoning for this is a little complicated:

1) I could exclude bin/* - but that way if someone creates a new bin/foo it won't be checked
2) I could exclude individual items like bin/bundle, bin/rails etc - but if someone does change it,
   their change won't be checked by rubocop

The same applies for other files, like things in config/* that are built by standard configs.

After some discussion with Anson, we've decided to replace all occurrences. The downside is that
if/when we do a rails upgrade, someone will have to compare a single-vs-double-quoted version of
the files in bin/* and similar to see if there are changes that need to be incorporated.