### PR TITLE
Docker container repository 92999546

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 # Dotenv 2.0 uses a .env.local instead of a plain .env
 # The .env file is now used for defaults, which are then overriden with per-environment .env.production style files
 .env.local
+
+# The Dockerfile is copied from docker/... to Dockerfile during builds via Makefile, since we can't
+# use the -f option to Docker (CircleCI's docker version is too old)
+/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,34 @@
 # The name of the image created by this project
 docker_image = defence-request-service
 
-# Produced tags is registry.service.dsd.io/defence-request-service/${docker_image}:tagvalue
-docker_publish_prefix = registry.service.dsd.io/defence-request-service
+# Produced tag is https://registry.hub.docker.com/u/oskarpearson/defence-request-service/${docker_image}:tagvalue
+docker_publish_prefix = oskarpearson
 
 # Default: tag and push containers
-all: build_all_containers tag push
+all: force_filesystem_timestamps build_all_containers tag push
 	echo Docker containers built and pushed successfully
+
+# Improve cacheability by forcing the timestamps of all files to be consistent across builds
+force_filesystem_timestamps:
+	find . -not -iwholename '*.git*' -exec touch -t 200001010000.00 {} \;
 
 # Build all docker containers
 build_all_containers: base_container development_container production_container
 
 base_container:
-	docker build -t "${docker_image}:base_localbuild" -f docker/Dockerfile-base .
+	cp -a docker/Dockerfile-base Dockerfile
+	docker build -t "${docker_image}:base_localbuild" .
+	rm -f Dockerfile
 
 development_container: base_container
-	docker build -t "${docker_image}:development_localbuild" -f docker/Dockerfile-development .
+	cp -a docker/Dockerfile-development Dockerfile
+	docker build -t "${docker_image}:development_localbuild" .
+	rm -f Dockerfile
 
 production_container: base_container
-	docker build -t "${docker_image}:production_localbuild" -f docker/Dockerfile-production .
+	cp -a docker/Dockerfile-production Dockerfile
+	docker build -t "${docker_image}:production_localbuild" .
+	rm -f Dockerfile
 
 # Tag repos
 tag:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,19 @@
 machine:
   ruby:
     version: 2.2.2
+  services:
+    - docker
 test:
   override:
     - bundle exec rake --trace
+deployment:
+  create_containers:
+    branch: [master, docker_container_repository_92999546]
+    commands:
+      # Log into the docker container. Note that this requires these environment variables
+      # to be stored in the CircleCI environment config
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      # Ensure that the docker container built contains absolutely nothing unexpected
+      # that might have been installed by CircleCI (eg an updated database.yml)
+      - (git clean -fd ; git reset --hard) || true
+      - DOCKER_IMAGE_TAG=$CIRCLE_BUILD_NUM annotate-output make

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ test:
     - bundle exec rake --trace
 deployment:
   create_containers:
-    branch: [master, docker_container_repository_92999546]
+    branch: master
     commands:
       # Log into the docker container. Note that this requires these environment variables
       # to be stored in the CircleCI environment config

--- a/circle.yml
+++ b/circle.yml
@@ -15,5 +15,6 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       # Ensure that the docker container built contains absolutely nothing unexpected
       # that might have been installed by CircleCI (eg an updated database.yml)
-      - (git clean -fd ; git reset --hard) || true
+      - git clean --force -d
+      - git reset --hard
       - DOCKER_IMAGE_TAG=$CIRCLE_BUILD_NUM annotate-output make

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,3 +15,7 @@ development:
 test:
   <<: *default
   database: defence-solicitor_test
+
+production:
+  <<: *default
+  database: defence-solicitor_production

--- a/docker/Dockerfile-development
+++ b/docker/Dockerfile-development
@@ -1,8 +1,5 @@
 FROM defence-request-service:base_localbuild
 
-# For developer use only
-ENV RAILS_ENV development
-
 # Base packages:
 #   - postgresql-client
 #
@@ -28,6 +25,7 @@ RUN ln -sf /usr/local/share/phantomjs-1.9.7-linux-x86_64/bin/phantomjs /usr/loca
 ###############################################################################
 # Defaults for executing container
 ###############################################################################
+ENV RAILS_ENV development
 VOLUME /usr/src/app
 WORKDIR /usr/src/app
 

--- a/docker/Dockerfile-production
+++ b/docker/Dockerfile-production
@@ -18,6 +18,13 @@ COPY . /usr/src/app
 WORKDIR /usr/src/app
 
 ###############################################################################
+# Defaults for executing container
+###############################################################################
+# Default environment variables for production runs
+ENV RAILS_ENV production
+ENV UNICORN_PORT 3000
+
+###############################################################################
 # Compile Assets
 ###############################################################################
 # To run 'rake assets:precompile' we need a set of environment variables, since
@@ -27,16 +34,8 @@ WORKDIR /usr/src/app
 # and we don't want to wait until boot time to run the asset precompile,
 # we use the environment variables in the .env.development file to run the precompile
 #
-COPY .env.development .env.local
 # Build assets, then clear all env files. including .env.local
-RUN bin/rake assets:clobber assets:precompile && rm -f .env.*
-
-###############################################################################
-# Defaults for executing container
-###############################################################################
-# Default environment variables for production runs
-ENV RAILS_ENV production
-ENV UNICORN_PORT 3000
+RUN cp .env.development .env.local && bin/rake assets:clobber assets:precompile && rm -f .env.*
 
 # Allow incoming connections on the Unicorn port
 EXPOSE $UNICORN_PORT


### PR DESCRIPTION
Until we have the secure repo and build system configured, we are going to use the public docker registry

* Reverted to the old way of handling multiple Dockerfiles, since CircleCI runs an older Docker release
* Improve caching of docker containers as per https://circleci.com/docs/docker#caching-docker-layers
* Build and push Docker containers on builds against certain branches
* Ensure that we set the Rails environment to Production before building assets
* Circleci overrides database.yml by default, which then gets committed to the Docker containers.
  Additionally it installs things in vendor and other places. We now force a git clean before building
  the container, so that only the things that should definitely be in the container are in the container.
* Add production database.yml config entry
* On building a docker container, force the filesystem timestamp to all be the same value. This helps
  ensure cacheability, since docker considers a timestamp difference to mean a change, and
  git doesn't preserve timestamps across builds.