### PR TITLE
WIP: Refactor features to use page object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :test do
   gem "poltergeist"
   gem "shoulda-matchers", require: false
   gem "simplecov", require: false
+  gem "site_prism", require: false
   gem "webmock", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,9 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
+    site_prism (2.7)
+      addressable (>= 2.3.3, < 3.0)
+      capybara (>= 2.1, < 3.0)
     slop (3.6.0)
     sprockets (3.0.2)
       rack (~> 1.0)
@@ -371,6 +374,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   shoulda-matchers
   simplecov
+  site_prism
   sucker_punch (~> 1.0)
   terminal-notifier-guard
   transitions

--- a/spec/features/solicitor/dashboard_spec.rb
+++ b/spec/features/solicitor/dashboard_spec.rb
@@ -3,43 +3,42 @@ require "rails_helper"
 RSpec.feature "Solicitors viewing their dashboard" do
   include DashboardHelper
 
-  specify "can only see requests that they have accepted" do
-    solicitor_user = create :solicitor_user
-    accepted_defence_request = create(
+  let(:dashboard_page) { SolicitorDashboardPage.new }
+
+  let!(:solicitor_user) { create :solicitor_user }
+  let!(:accepted_defence_request) do
+    create(
       :defence_request,
       :accepted,
       solicitor_uid: solicitor_user.uid,
       organisation_uid: solicitor_user.organisation_uids.first,
       offences: "Arson"
     )
-    not_accepted_defence_request = create :defence_request, offences: "Extortion"
+  end
+
+  before do
+    create :defence_request, offences: "Extortion"
 
     login_with solicitor_user
+  end
 
-    expect(page).to have_content accepted_defence_request.offences
-    expect(page).to_not have_content not_accepted_defence_request.offences
+  specify "can only see requests that they have accepted" do
+    expect(dashboard_page).to have_defence_requests(count: 1)
+    expect(dashboard_page.defence_requests.first).to match_defence_request(accepted_defence_request)
   end
 
   context "when the dashboard refreshes to update defence request information" do
-    specify "they can still only see requests the they have accepted", js: true, short_dashboard_refresh: true do
-      solicitor_user = create :solicitor_user
-      accepted_defence_request = create(
-        :defence_request,
-        :accepted,
-        solicitor_uid: solicitor_user.uid,
-        organisation_uid: solicitor_user.organisation_uids.first
-      )
-      acknowledged_defence_request = create :defence_request, :acknowledged
-
-      login_with solicitor_user
-
-      expect(page).to have_content(accepted_defence_request.detainee_name)
-      expect(page).to_not have_content(acknowledged_defence_request.detainee_name)
+    specify "they can still only see requests the they have accepted", js: true do
+      expect(dashboard_page).to have_defence_requests(count: 1)
+      expect(dashboard_page.defence_requests.first).to match_defence_request(accepted_defence_request)
 
       refresh_dashboard
 
-      expect(page).to have_content(accepted_defence_request.detainee_name)
-      expect(page).to_not have_content(acknowledged_defence_request.detainee_name)
+      # Fixme this should use more appropriate way of waiting, but for a demo this is sufficient
+      sleep(0.1)
+
+      expect(dashboard_page).to have_defence_requests(count: 1)
+      expect(dashboard_page.defence_requests.first).to match_defence_request(accepted_defence_request)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
 require "shoulda-matchers"
 require "capybara/poltergeist"
+require "site_prism"
 require "omniauth-dsds/spec/sign_in_helper"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }

--- a/spec/support/ui/matchers.rb
+++ b/spec/support/ui/matchers.rb
@@ -1,0 +1,16 @@
+RSpec::Matchers.define :match_defence_request do |expected|
+  match do |actual|
+    @errors = []
+
+    @errors << :time_of_arrival unless actual.time_of_arrival.text == expected.time_of_arrival.to_s(:time)
+    @errors << :detainee_name unless actual.detainee_name.text == expected.detainee_name
+    @errors << :offences unless actual.offences.text == expected.offences
+    @errors << :dscc unless actual.dscc.text == expected.dscc_number
+
+    @errors.empty?
+  end
+
+  failure_message do |_|
+    "some defence request properties are not matching: #{@errors.join(", ")}"
+  end
+end

--- a/spec/support/ui/pages/solicitor_dashboard.rb
+++ b/spec/support/ui/pages/solicitor_dashboard.rb
@@ -1,0 +1,5 @@
+require_relative "../sections/defence_request"
+
+class SolicitorDashboardPage < SitePrism::Page
+  sections :defence_requests, DefenceRequestSection, "section.defence-requests .defence-request-box"
+end

--- a/spec/support/ui/sections/defence_request.rb
+++ b/spec/support/ui/sections/defence_request.rb
@@ -1,0 +1,6 @@
+class DefenceRequestSection < SitePrism::Section
+  element :time_of_arrival, ".time-of-arrival"
+  element :detainee_name, ".name"
+  element :offences, ".offences"
+  element :dscc, ".dscc"
+end


### PR DESCRIPTION
This PR is not to be merged, but as a discussion about this approach to feature testing. 

There's a couple of reasons for using similar approach:

1. With `page.have_content`, there's a big risk of false positives, because of ambiguity. For example testing that a time 11:50 is on the page, it can be anywhere on the page.

2. The HTML is abstracted from the tests, which makes them shorted and more readable. Also if the markup changes, only the page objects are changed, not feature files.

3. Sections can be re-used or replaced. So for example when testing different version for mobile or desktop (could be different markup), only the page object definition will be swapped, features can be the same.

4. It helps focusing on relevant page content and avoiding negative testing (something is not on the page).