### PR TITLE
Fix generating dscc_number on acknowledge

### DIFF
--- a/app/models/defence_request_transitions/acknowledge.rb
+++ b/app/models/defence_request_transitions/acknowledge.rb
@@ -18,7 +18,7 @@ module DefenceRequestTransitions
     end
 
     def acknowledge_defence_request
-      run_transition && defence_request.save!
+      run_transition && defence_request.save! && defence_request.generate_dscc_number!
     end
 
     def run_transition

--- a/app/models/defence_request_transitions/acknowledge.rb
+++ b/app/models/defence_request_transitions/acknowledge.rb
@@ -17,6 +17,9 @@ module DefenceRequestTransitions
       return true if defence_request.cco_uid = user.uid
     end
 
+    # Note: In the unlikely event that we cannot generate a dscc_number the dr
+    # is going to end up in a broken state. We will move this into a delayed
+    # job where we will handle this case.
     def acknowledge_defence_request
       run_transition && defence_request.save! && defence_request.generate_dscc_number!
     end

--- a/spec/features/cco/defence_request_management_spec.rb
+++ b/spec/features/cco/defence_request_management_spec.rb
@@ -36,12 +36,15 @@ RSpec.feature "Call Center Operatives managing defence requests" do
 
       specify "can acknowledge the request" do
         cco_user = create :cco_user
-        create :defence_request, :queued, cco_uid: cco_user.uid
+        dr =  create :defence_request, :queued, cco_uid: cco_user.uid
 
         login_with cco_user
         click_button "Acknowledge"
 
         expect(page).to have_content "Defence Request successfully acknowledged"
+
+        click_link "Show"
+        expect(page).to have_content "#{dr.dscc_number}"
       end
 
       specify "are shown a message if the request cannot be acknowledged" do
@@ -123,7 +126,7 @@ RSpec.feature "Call Center Operatives managing defence requests" do
           create(
             :defence_request,
             :acknowledged,
-            dscc_number: "012345",
+            :with_dscc_number,
             cco_uid: cco_user.uid
           )
 

--- a/spec/models/defence_request_transitions/acknowledge_spec.rb
+++ b/spec/models/defence_request_transitions/acknowledge_spec.rb
@@ -32,4 +32,20 @@ RSpec.describe DefenceRequestTransitions::Acknowledge, "#complete" do
     expect(defence_request).not_to have_received(:save!)
     expect(transition).to eq false
   end
+
+  it "returns false if a dscc_number could not be generated" do
+    defence_request = spy(:defence_request)
+    user = spy(:user, uid: SecureRandom.uuid)
+
+    expect(defence_request).to receive(:generate_dscc_number!).and_return(false)
+
+    transition = DefenceRequestTransitions::Acknowledge.new(
+      defence_request: defence_request,
+      user: user,
+    ).complete
+
+    expect(defence_request).to have_received(:cco_uid=).with(user.uid)
+    expect(defence_request).to have_received(:save!)
+    expect(transition).to eq false
+  end
 end


### PR DESCRIPTION
This somehow got lost in a rebase.