### PR TITLE
[use_moj_base_container] Use MOJ base container

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,11 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       # Ensure that the docker container built contains absolutely nothing unexpected
       # that might have been installed by CircleCI (eg an updated database.yml)
+      #
+      # We delete vendor/bundle and .bundle here individually, since the
+      # vendor/bundle/ruby/2.2.0/bundler/gems/defence-request-service-omniauth-dsds-ad15dbb76c9e git checkout
+      # isn't deleted by git clean as it's a submodule
+      - rm -rf vendor/bundle .bundle
       - git clean --force -d
       - git reset --hard
       - DOCKER_IMAGE_TAG=$CIRCLE_BUILD_NUM annotate-output make

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -1,12 +1,4 @@
-FROM ruby:2.2.2
-
-# **This always needs to be the very first step.**
-# If you 'date +%s > latest-security-upgrades' and commit it, the latest security updates
-# will be appplied, because every later step will be invalidated
-ENV HOME /root
-ENV DEBIAN_FRONTEND noninteractive
-ADD .latest-security-upgrades /.latest-security-upgrades
-RUN apt-get update && apt-get -y upgrade
+FROM ministryofjustice/docker-moj-base:latest
 
 ##############################################################################
 # Copy helper scripts into the container:
@@ -15,10 +7,38 @@ RUN apt-get update && apt-get -y upgrade
 ADD docker/bin/clean-up-docker-container /usr/local/bin/clean-up-docker-container
 
 ##############################################################################
+# Apply Security Upgrades
+##############################################################################
+# **This always needs to be the very first step after installing the helper scripts.**
+# If you 'date +%s > latest-security-upgrades' and commit it, the latest security updates
+# will be appplied, because every later step will be invalidated
+ENV HOME /root
+ENV DEBIAN_FRONTEND noninteractive
+ADD .latest-security-upgrades /.latest-security-upgrades
+RUN apt-get update && apt-get -y upgrade && /usr/local/bin/clean-up-docker-container
+
+# FIXME: Currently we're using brightbox's ruby 2.2.2 release, since we don't have
+# a repo.dsd.io release of ruby 2.2.2. See story #93634238
+# Instructions: https://www.brightbox.com/docs/ruby/ubuntu/
+RUN echo "deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main" > /etc/apt/sources.list.d/brightbox-ruby-ng-trusty.list \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6 \
+  && apt-get update && apt-get -y upgrade \
+  && apt-get install -y --no-install-recommends git ruby2.2 ruby2.2-dev \
+  && gem install bundler \
+  && /usr/local/bin/clean-up-docker-container
+
+##############################################################################
 # Add packages required by the codebase
 ##############################################################################
-# * NodeJS - Javascript runtime environment
-RUN apt-get update && apt-get install -y nodejs
+# * build-essential - To compile code
+# * libpq-dev - for connecting to a postgresql database
+# * libxslt1.1 - for nokogiri
+# * libyaml-0-2 - faster yaml parsing
+# * nodejs - Javascript runtime environment
+# * zlib1g-dev - for nokogiri
+RUN apt-get update \
+  && apt-get install -y build-essential libpq-dev libxslt1.1 libyaml-0-2 nodejs \
+  && /usr/local/bin/clean-up-docker-container
 
 ##############################################################################
 # Required Gems
@@ -31,4 +51,4 @@ RUN apt-get update && apt-get install -y nodejs
 #
 ADD Gemfile /tmp/gemfile-when-docker-image-built/Gemfile
 ADD Gemfile.lock /tmp/gemfile-when-docker-image-built/Gemfile.lock
-RUN bundle install --gemfile=/tmp/gemfile-when-docker-image-built/Gemfile
+RUN bundle install --gemfile=/tmp/gemfile-when-docker-image-built/Gemfile && /usr/local/bin/clean-up-docker-container

--- a/docker/Dockerfile-production
+++ b/docker/Dockerfile-production
@@ -8,7 +8,7 @@ RUN touch /etc/inittab
 
 # Add application server
 COPY ./docker/runit/application-server/run /etc/service/application-server/run
-RUN chmod +x /etc/service/application-server
+RUN chmod +x /etc/service/application-server/run
 
 ###############################################################################
 # Add code and set work directory. Generally everything from this
@@ -43,6 +43,9 @@ EXPOSE $UNICORN_PORT
 # Add volumes for log files
 VOLUME /usr/src/app/logs
 VOLUME /var/log
+
+# Don't run logstash, statsd, or sshd
+RUN rm -rf /etc/service/logstash /etc/service/statsd /etc/service/sshd
 
 # Run all services by default
 CMD ["/usr/bin/runsvdir", "-P", "/etc/service"]


### PR DESCRIPTION
Use MOJ base container as the base of our containers. This way we
include things from their secure registry, any security changes, and so
forth.