### PR TITLE
Use un-prefixed env vars for db connection

### DIFF
--- a/docker/bin/run-in-docker-compose
+++ b/docker/bin/run-in-docker-compose
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-export DATABASE_URL="postgres://postgres:postgres@$DEFENCEREQUESTSERVICEDEPLOY_DB_1_PORT_5432_TCP_ADDR:$DEFENCEREQUESTSERVICEDEPLOY_DB_1_PORT_5432_TCP_PORT/$DB_NAME"
+export DATABASE_URL="postgres://postgres:postgres@${DB_1_PORT_5432_TCP_ADDR}:${DB_1_PORT_5432_TCP_PORT}/${DB_NAME}"
 
 # Clear out any assets that exist in the volume, and then make sure the DB exists and contains useful info
 bundle exec rake assets:clobber db:reset


### PR DESCRIPTION
Turns out the environment variables for the db 
connection exist in a non-prefixed format as 
well. 

Using the more generic version allows us
to use this boot script for multiple docker
compose repos.