### PR TITLE
Allow solicitor to see organisation defence request detail

### DIFF
--- a/app/policies/solicitor_defence_request_policy.rb
+++ b/app/policies/solicitor_defence_request_policy.rb
@@ -28,12 +28,16 @@ class SolicitorDefenceRequestPolicy < ApplicationPolicy
   end
 
   def show?
-    user_is_the_assigned_solicitor && !policy_record.draft?
+    (user_is_the_assigned_solicitor || user_is_from_the_same_organisation) && !policy_record.draft?
   end
 
   private
 
   def user_is_the_assigned_solicitor
     policy_record.solicitor_uid == policy_user.uid
+  end
+
+  def user_is_from_the_same_organisation
+    policy_user.organisation_uids.include?(policy_record.organisation_uid)
   end
 end

--- a/spec/policies/solicitor_defence_request_policy_spec.rb
+++ b/spec/policies/solicitor_defence_request_policy_spec.rb
@@ -31,9 +31,15 @@ RSpec.describe SolicitorDefenceRequestPolicy do
     end
 
     context "DR their organisation is assigned to" do
-      context "with a DR which is not a draft" do
+      context "not in draft state" do
         let(:allowed_actions) { [ :show ] }
         let(:defreq) { FactoryGirl.create(:defence_request, :accepted, organisation_uid: user.organisation_uids.first) }
+        specify { expect(subject).to permit_actions_and_forbid_all_others actions }
+      end
+
+      context "in draft state" do
+        let(:allowed_actions) { [] }
+        let(:defreq) { FactoryGirl.create(:defence_request, :draft, organisation_uid: user.organisation_uids.first) }
         specify { expect(subject).to permit_actions_and_forbid_all_others actions }
       end
     end

--- a/spec/policies/solicitor_defence_request_policy_spec.rb
+++ b/spec/policies/solicitor_defence_request_policy_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe SolicitorDefenceRequestPolicy do
       end
     end
 
+    context "DR their organisation is assigned to" do
+      context "with a DR which is not a draft" do
+        let(:allowed_actions) { [ :show ] }
+        let(:defreq) { FactoryGirl.create(:defence_request, :accepted, organisation_uid: user.organisation_uids.first) }
+        specify { expect(subject).to permit_actions_and_forbid_all_others actions }
+      end
+    end
+
     context "DR they are not assigned to" do
       let (:other_solicitor) { FactoryGirl.create(:solicitor_user) }
 


### PR DESCRIPTION
This may as well change in the future, when we have the roles defined more clearly. But for the moment solicitor has to be able to see the detail.