### PR TITLE
[RFC] Reload resistant registry

### DIFF
--- a/lib/service_registry.rb
+++ b/lib/service_registry.rb
@@ -1,5 +1,5 @@
 class ServiceRegistry
-  ServiceNotRegistered = Class.new(ArgumentError)
+  class ServiceNotRegistered < ArgumentError; end
 
   def self.register(name, service)
     services.store(name, service)

--- a/lib/service_registry.rb
+++ b/lib/service_registry.rb
@@ -2,7 +2,7 @@ class ServiceRegistry
   ServiceNotRegistered = Class.new(ArgumentError)
 
   def self.register(name, service)
-    services[name] = service
+    services.store(name, service)
   end
 
   def self.service(name)
@@ -12,6 +12,19 @@ class ServiceRegistry
   end
 
   def self.services
-    @services ||= {}
+    ServiceRegistryStore
+  end
+end
+
+class ServiceRegistryStore
+  class << self
+    extend Forwardable
+    def_delegators :services, :fetch, :store
+
+    private
+
+    def services
+      @store ||= {}
+    end
   end
 end

--- a/spec/lib/service_registry_spec.rb
+++ b/spec/lib/service_registry_spec.rb
@@ -3,31 +3,30 @@ require_relative "../../lib/service_registry"
 
 RSpec.describe ServiceRegistry do
 
-  subject(:registry) { described_class }
   let(:service) { double }
 
   before do
-    registry.register(:existing, service)
+    ServiceRegistry.register(:existing, service)
   end
 
   describe ".register" do
     it "stores the given service" do
-      described_class.register(:new, service)
+      ServiceRegistry.register(:new, service)
 
-      expect(described_class.service(:new)).to eq service
+      expect(ServiceRegistry.service(:new)).to eq service
     end
   end
 
   describe ".service" do
     context "when service is registered" do
       it "returns the service" do
-        expect(registry.service(:existing)).to be(service)
+        expect(ServiceRegistry.service(:existing)).to be(service)
       end
     end
 
     context "when service is not registered" do
       it "raises ServiceNotRegistered exception" do
-        expect { registry.service(:non_existent) }.to raise_error(ServiceRegistry::ServiceNotRegistered)
+        expect { ServiceRegistry.service(:non_existent) }.to raise_error(ServiceRegistry::ServiceNotRegistered)
       end
     end
   end
@@ -38,7 +37,7 @@ RSpec.describe ServiceRegistry do
       registered_service = double
       ServiceRegistry.register :registered_service, registered_service
 
-      service_registry_path = File.join(File.dirname(__FILE__), '../../lib/service_registry.rb')
+      service_registry_path = File.join(File.dirname(__FILE__), "../../lib/service_registry.rb")
       Object.send :remove_const, :ServiceRegistry
       load service_registry_path
 

--- a/spec/lib/service_registry_spec.rb
+++ b/spec/lib/service_registry_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ServiceRegistry do
     it "stores the given service" do
       described_class.register(:new, service)
 
-      expect(described_class.services).to include(:new => service)
+      expect(described_class.service(:new)).to eq service
     end
   end
 
@@ -29,6 +29,20 @@ RSpec.describe ServiceRegistry do
       it "raises ServiceNotRegistered exception" do
         expect { registry.service(:non_existent) }.to raise_error(ServiceRegistry::ServiceNotRegistered)
       end
+    end
+  end
+
+
+  context "when the class gets reloaded" do
+    it "the service store is persisted" do
+      registered_service = double
+      ServiceRegistry.register :registered_service, registered_service
+
+      service_registry_path = File.join(File.dirname(__FILE__), '../../lib/service_registry.rb')
+      Object.send :remove_const, :ServiceRegistry
+      load service_registry_path
+
+      expect(ServiceRegistry.service :registered_service).to eq registered_service
     end
   end
 end


### PR DESCRIPTION
In development mode, rails likes to reload
classes. Unfortunately this means our registry
gets clobbered, and a new singleton object is
instantiated - losing any services we registered
in initialisers. 

Keeping a separate class to use as the store
protects the service hash itself from being 
recreated (due to rails only expecting the
ServiceRegistry class to be residing in that
file)