### PR TITLE
Save defence_request after acknowledge

### DIFF
--- a/app/models/defence_request_transitions/acknowledge.rb
+++ b/app/models/defence_request_transitions/acknowledge.rb
@@ -29,7 +29,7 @@ module DefenceRequestTransitions
         false
       else
         defence_request.organisation_uid = organisations.first.uid
-        true
+        defence_request.save!
       end
     end
 

--- a/app/models/defence_request_transitions/acknowledge.rb
+++ b/app/models/defence_request_transitions/acknowledge.rb
@@ -29,7 +29,6 @@ module DefenceRequestTransitions
         false
       else
         defence_request.organisation_uid = organisations.first.uid
-        defence_request.save!
       end
     end
 
@@ -37,7 +36,11 @@ module DefenceRequestTransitions
     # is going to end up in a broken state. We will move this into a delayed
     # job where we will handle this case.
     def acknowledge_defence_request
-      run_transition && defence_request.save! && defence_request.generate_dscc_number! && set_organisation_uid
+      run_transition &&
+        set_organisation_uid &&
+        defence_request.valid? &&
+        defence_request.generate_dscc_number! &&
+        defence_request.save
     end
 
     def run_transition

--- a/spec/models/defence_request_transitions/acknowledge_spec.rb
+++ b/spec/models/defence_request_transitions/acknowledge_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DefenceRequestTransitions::Acknowledge, "#complete", :mock_auth_a
     expect(result).to eq false
   end
 
-  context "something" do
+  context "the api does not return a law firm" do
     let(:auth_api_mock_setup) do
       {
         organisations: {

--- a/spec/models/defence_request_transitions/acknowledge_spec.rb
+++ b/spec/models/defence_request_transitions/acknowledge_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe DefenceRequestTransitions::Acknowledge, "#complete", :mock_auth_a
 
   it "transitions the defence request to acknowledge state" do
     result = subject
+    defence_request.reload
 
     expect(defence_request.cco_uid).to eql(user.uid)
     expect(defence_request.dscc_number).not_to be_empty
@@ -61,9 +62,7 @@ RSpec.describe DefenceRequestTransitions::Acknowledge, "#complete", :mock_auth_a
     end
 
     it "returns false if an organisation is not assigned" do
-
       result = subject
-
       expect(defence_request).to be_acknowledged
       expect(result).to eq false
     end


### PR DESCRIPTION
We were not saving the request after adding a
organisation_uid, so no association to a firm
/solicitor was being made.