### PR TITLE
Require service registry manually

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,8 +57,6 @@ module DefenceSolicitor
     config.action_mailer.default_url_options = Settings.action_mailer.default_url_options.to_h
     config.action_mailer.smtp_settings = Settings.action_mailer.smtp_settings.to_h
 
-    config.autoload_paths += %W(#{config.root}/lib)
-
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.active_record.raise_in_transactional_callbacks = true
   end

--- a/config/initializers/drs-auth_client.rb
+++ b/config/initializers/drs-auth_client.rb
@@ -1,3 +1,5 @@
+require_relative "../../lib/service_registry.rb"
+
 Drs::AuthClient.configure do |client|
   client.host = Settings.authentication.site_url
   client.version = :v1


### PR DESCRIPTION
The service registry singleton has a store that added to in the initialisers, this means trouble if the class gets reloaded - and the store gets clobbered.