### PR TITLE
Optional text grey on Defence Request form

### DIFF
--- a/app/assets/stylesheets/govuk_elements_extensions.scss
+++ b/app/assets/stylesheets/govuk_elements_extensions.scss
@@ -56,6 +56,10 @@ select {
   @extend .form-label;
 }
 
+aside, .aside {
+  color: $grey-2;
+}
+
 span.hint {
   @extend .form-hint;
   margin-top: 0px;
@@ -64,7 +68,6 @@ span.hint {
 label + input, label + textarea {
   @extend .form-control;
 }
-
 
 fieldset, .sub-panel {
   @extend .form-group;

--- a/app/helpers/defence_requests_helper.rb
+++ b/app/helpers/defence_requests_helper.rb
@@ -49,7 +49,7 @@ module DefenceRequestsHelper
 
   def label_text_for_form(attribute_name:, optional: false)
     if optional
-      "#{t(attribute_name.to_s)} (#{t("optional")})"
+      "#{t(attribute_name.to_s)} <span class=\"aside\">(#{t("optional")})</span>".html_safe
     else
       t(attribute_name.to_s)
     end

--- a/app/views/defence_requests/form_partials/_case_details.html.erb
+++ b/app/views/defence_requests/form_partials/_case_details.html.erb
@@ -39,6 +39,6 @@
 
 <div class="form-group">
   <%= f.label :comments, label_text_for_form(attribute_name: "comments", optional: true), class: "form-label-bold" %>
-  <aside>E.g samples required, Section 18 House Search or full medical examination</aside>
+  <aside><%= t("comments_field_aside_text") %></aside>
   <%= f.text_area :comments, label: t('comments'), rows: '5', class: 'text-field text-field-wide' %>
 </div>

--- a/app/views/defence_requests/form_partials/_case_details.html.erb
+++ b/app/views/defence_requests/form_partials/_case_details.html.erb
@@ -38,7 +38,9 @@
 </div>
 
 <div class="form-group">
-  <%= f.label :comments, label_text_for_form(attribute_name: "comments", optional: true), class: "form-label-bold" %>
-  <aside><%= t("comments_field_aside_text") %></aside>
+  <%= f.label :comments, class: "form-label-bold" do %>
+    <%= label_text_for_form(attribute_name: "comments", optional: true) %>
+    <aside><%= t("comments_field_aside_text") %></aside>
+  <%- end %>
   <%= f.text_area :comments, label: t('comments'), rows: '5', class: 'text-field text-field-wide' %>
 </div>

--- a/app/views/defence_requests/form_partials/_case_details.html.erb
+++ b/app/views/defence_requests/form_partials/_case_details.html.erb
@@ -28,12 +28,12 @@
 </div>
 
 <div class="form-group">
-  <%= f.label :investigating_officer_name, label_text_for_form(attribute_name: 'investigating_officer_name'), class: "form-label-bold" %>
+  <%= f.label :investigating_officer_name, label_text_for_form(attribute_name: 'investigating_officer_name', optional: true), class: "form-label-bold" %>
   <%= f.text_field :investigating_officer_name, label: t('investigating_officer_name'), class: 'text-field custody-number' %>
 </div>
 
 <div class="form-group">
-  <%= f.label :investigating_officer_contact_number, label_text_for_form(attribute_name: 'investigating_officer_contact_number'), class: "form-label-bold" %>
+  <%= f.label :investigating_officer_contact_number, label_text_for_form(attribute_name: 'investigating_officer_contact_number', optional: true), class: "form-label-bold" %>
   <%= f.text_field :investigating_officer_contact_number, label: t('investigating_officer_contact_number'), class: 'text-field custody-number' %>
 </div>
 

--- a/app/views/defence_requests/form_partials/_case_details.html.erb
+++ b/app/views/defence_requests/form_partials/_case_details.html.erb
@@ -39,5 +39,6 @@
 
 <div class="form-group">
   <%= f.label :comments, label_text_for_form(attribute_name: "comments", optional: true), class: "form-label-bold" %>
+  <aside>E.g samples required, Section 18 House Search or full medical examination</aside>
   <%= f.text_area :comments, label: t('comments'), rows: '5', class: 'text-field text-field-wide' %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
   circumstances_of_arrest: Circumstances of arrest
   closed: "Closed (%{count})"
   comments: "Comments"
+  comments_field_aside_text: "E.g samples required, Section 18 House Search or full medical examination"
   complete: Complete
   completed: "Completed (%{count})"
   confirm: "Confirm"

--- a/spec/helpers/defence_requests_helper_spec.rb
+++ b/spec/helpers/defence_requests_helper_spec.rb
@@ -96,4 +96,19 @@ RSpec.describe DefenceRequestsHelper, type: :helper do
     end
   end
 
+  describe "label_text_for_form" do
+    context "when the label is optional" do
+      it "renders the translation of the attribute name" do
+        output = helper.label_text_for_form(attribute_name: "detainee_name", optional: true)
+        expect(output).to eq("Detainee name <span class=\"aside\">(optional)</span>")
+      end
+    end
+
+    context "when the label is required" do
+      it "renders the translation of the attribute name" do
+        output = helper.label_text_for_form(attribute_name: "detainee_name")
+        expect(output).to eq("Detainee name")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Renders the "optional" label text as grey

Story: https://www.pivotaltracker.com/story/show/95982466