### PR TITLE
Defence request form tweaks

### DIFF
--- a/app/models/defence_request.rb
+++ b/app/models/defence_request.rb
@@ -59,10 +59,13 @@ class DefenceRequest < ActiveRecord::Base
 
 
 
+  validates :appropriate_adult, inclusion: { in: [true, false], message: :blank }
   validates :appropriate_adult_reason, presence: true, if: :appropriate_adult?
 
-  validates :unfit_for_interview_reason, presence: true, unless: :fit_for_interview?
+  validates :fit_for_interview, inclusion: { in: [true, false], message: :blank }
+  validates :unfit_for_interview_reason, presence: true, if: -> (dr) { !dr.fit_for_interview.nil? && !dr.fit_for_interview? }
 
+  validates :interpreter_required, inclusion: { in: [true, false], message: :blank }
   validates :interpreter_type, presence: true, if: :interpreter_required
 
   validates :dscc_number, uniqueness: true, allow_nil: true

--- a/app/views/defence_requests/form_partials/_case_details.html.erb
+++ b/app/views/defence_requests/form_partials/_case_details.html.erb
@@ -12,11 +12,11 @@
   <fieldset class="inline">
     <%= f.label :fit_for_interview, label_text_for_form(attribute_name: 'fit_for_interview'), class: "form-label-bold" %>
     <label class="block-label form-label" for="defence_request_fit_for_interview_true">
-      <%= f.radio_button :fit_for_interview, true, name: 'defence_request[fit_for_interview]', checked: @defence_request.fit_for_interview.present?, class: 'fit_for_interview_radio' %>
+      <%= f.radio_button :fit_for_interview, true, name: 'defence_request[fit_for_interview]', class: 'fit_for_interview_radio' %>
       <%= t('yes') %>
     </label>
     <label class="block-label form-label" for="defence_request_fit_for_interview_false">
-      <%= f.radio_button :fit_for_interview, false, name: 'defence_request[fit_for_interview]', checked: @defence_request.fit_for_interview.blank?, class: 'fit_for_interview_radio' %>
+      <%= f.radio_button :fit_for_interview, false, name: 'defence_request[fit_for_interview]', class: 'fit_for_interview_radio' %>
       <%= t('no') %>
     </label>
   </fieldset>

--- a/app/views/defence_requests/form_partials/_detainee_details.html.erb
+++ b/app/views/defence_requests/form_partials/_detainee_details.html.erb
@@ -37,13 +37,11 @@
     <%= f.label :appropriate_adult, label_text_for_form(attribute_name: 'appropriate_adult'), class: "form-label-bold" %>
     <label class="block-label form-label" for="defence_request_appropriate_adult_true">
       <%= f.radio_button :appropriate_adult, true, name: 'defence_request[appropriate_adult]',
-                         checked: @defence_request.appropriate_adult.present?,
                          class: 'appropriate_adult_radio' %>
       <%= t('yes') %>
     </label>
     <label class="block-label form-label" for="defence_request_appropriate_adult_false">
       <%= f.radio_button :appropriate_adult, false, name: 'defence_request[appropriate_adult]',
-                         checked: @defence_request.appropriate_adult.blank?,
                          class: 'appropriate_adult_radio' %>
       <%= t('no') %>
     </label>
@@ -60,13 +58,11 @@
     <%= f.label :interpreter_required, label_text_for_form(attribute_name: 'interpreter_required'), class: "form-label-bold" %>
     <label class="block-label form-label" for="defence_request_interpreter_required_true">
       <%= f.radio_button :interpreter_required, true, name: 'defence_request[interpreter_required]',
-                         checked: @defence_request.interpreter_required.present?,
                          class: 'interpreter_required_radio' %>
       <%= t('yes') %>
     </label>
     <label class="block-label form-label" for="defence_request_interpreter_required_false">
       <%= f.radio_button :interpreter_required, false, name: 'defence_request[interpreter_required]',
-                         checked: @defence_request.interpreter_required.blank?,
                          class: 'interpreter_required_radio' %>
       <%= t('no') %>
     </label>

--- a/app/views/defence_requests/form_partials/_form_actions.html.erb
+++ b/app/views/defence_requests/form_partials/_form_actions.html.erb
@@ -1,18 +1,13 @@
 <% if @defence_request_form.defence_request.new_record? %>
   <%= f.submit class: 'button' %>
   <div class="form-links">
-    <%= link_to t('cancel_and_delete_all_details'), defence_requests_path %>
-  </div>
-<% elsif @defence_request_form.defence_request.draft? %>
-  <%= f.submit class: 'button' %>
-  <div class="form-links">
-    <%= link_to t('cancel'), defence_request_path %>
+    <%= link_to t('cancel_and_delete_all_details'), dashboard_path %>
   </div>
 <% else %>
   <%= f.submit class: 'button' %>
   <%= f.submit(t('update_and_accept'), class: 'button warning') if @policy.dscc_number_edit? %>
   <div class="form-links">
-    <%= link_to t('cancel'), defence_requests_path %>
+    <%= link_to t('cancel'), defence_request_path %>
     <%= link_to t('abort'), abort_defence_request_path(@defence_request_form.defence_request) if @policy.abort? %>
   </div>
 <% end %>

--- a/db/migrate/20150602155851_remove_default_values_from_radio_buttons_on_defence_request.rb
+++ b/db/migrate/20150602155851_remove_default_values_from_radio_buttons_on_defence_request.rb
@@ -1,0 +1,13 @@
+class RemoveDefaultValuesFromRadioButtonsOnDefenceRequest < ActiveRecord::Migration
+  def up
+    change_column_default :defence_requests, :appropriate_adult, nil
+    change_column_default :defence_requests, :fit_for_interview, nil
+    change_column_default :defence_requests, :interpreter_required, nil
+  end
+
+  def down
+    change_column_default :defence_requests, :appropriate_adult, false
+    change_column_default :defence_requests, :fit_for_interview, true
+    change_column_default :defence_requests, :interpreter_required, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150529154920) do
+ActiveRecord::Schema.define(version: 20150602155851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 20150529154920) do
     t.datetime "time_of_arrival"
     t.text     "comments"
     t.boolean  "adult"
-    t.boolean  "appropriate_adult",                    default: false, null: false
+    t.boolean  "appropriate_adult",                                    null: false
     t.string   "state"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -64,9 +64,9 @@ ActiveRecord::Schema.define(version: 20150529154920) do
     t.uuid     "cco_uid"
     t.datetime "time_of_arrest"
     t.datetime "time_of_detention_authorised"
-    t.boolean  "fit_for_interview",                    default: true,  null: false
+    t.boolean  "fit_for_interview",                                    null: false
     t.text     "unfit_for_interview_reason"
-    t.boolean  "interpreter_required",                 default: false, null: false
+    t.boolean  "interpreter_required",                                 null: false
     t.text     "interpreter_type"
     t.uuid     "organisation_uid"
     t.string   "detainee_address"

--- a/spec/factories/defence_request.rb
+++ b/spec/factories/defence_request.rb
@@ -23,6 +23,7 @@ FactoryGirl.define do
     adult [nil, true, false].sample
     appropriate_adult false
     fit_for_interview true
+    interpreter_required false
     detainee_address_not_given "1"
   end
 

--- a/spec/models/defence_request_spec.rb
+++ b/spec/models/defence_request_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe DefenceRequest, type: :model do
     it { expect(subject).to validate_presence_of :detainee_name }
     it { expect(subject).to validate_presence_of :offences }
 
+    it { is_expected.to validate_presence_of(:appropriate_adult)}
+    it { is_expected.to validate_presence_of(:fit_for_interview)}
+    it { is_expected.to validate_presence_of(:interpreter_required)}
+
     context "appropriate_adult_reason required" do
       before do
         subject.appropriate_adult = true


### PR DESCRIPTION
There are 2 main changes:

* The radio buttons on the Defence Request form are no longer pre-selected
* The cancel link on `new` form links to the dashboard and on the `edit` form links to the show page.