### PR TITLE
Reasons for appropriate adult needed and detainee fit for interview

### DIFF
--- a/app/helpers/defence_requests_helper.rb
+++ b/app/helpers/defence_requests_helper.rb
@@ -87,4 +87,12 @@ module DefenceRequestsHelper
     end
   end
 
+  def appropriate_adult_reason(defence_request)
+    if defence_request.appropriate_adult?
+      reason = t(defence_request.appropriate_adult_reason).downcase
+      ["–", t("appropriate_adult_reason").downcase, reason].join(" ")
+    else
+      ""
+    end
+  end
 end

--- a/app/models/defence_request.rb
+++ b/app/models/defence_request.rb
@@ -57,10 +57,10 @@ class DefenceRequest < ActiveRecord::Base
             :gender,
             :time_of_arrival, presence: true
 
-
-
   validates :appropriate_adult, inclusion: { in: [true, false], message: :blank }
-  validates :appropriate_adult_reason, presence: true, if: :appropriate_adult?
+  validates :appropriate_adult_reason, presence: true,
+            inclusion: { in: %w(detainee_juvenile detainee_with_mental_issue) },
+            if: :appropriate_adult?
 
   validates :fit_for_interview, inclusion: { in: [true, false], message: :blank }
   validates :unfit_for_interview_reason, presence: true, if: -> (dr) { !dr.fit_for_interview.nil? && !dr.fit_for_interview? }

--- a/app/views/defence_requests/form_partials/_case_details.html.erb
+++ b/app/views/defence_requests/form_partials/_case_details.html.erb
@@ -10,7 +10,7 @@
 
 <div class="form-group">
   <fieldset class="inline">
-    <%= f.label :fit_for_interview, label_text_for_form(attribute_name: 'fit_for_interview'), class: "form-label-bold" %>
+    <%= f.label :fit_for_interview, label_text_for_form(attribute_name: 'fit_for_interview') + "?", class: "form-label-bold" %>
     <label class="block-label form-label" for="defence_request_fit_for_interview_true">
       <%= f.radio_button :fit_for_interview, true, name: 'defence_request[fit_for_interview]', class: 'fit_for_interview_radio' %>
       <%= t('yes') %>

--- a/app/views/defence_requests/form_partials/_case_details.html.erb
+++ b/app/views/defence_requests/form_partials/_case_details.html.erb
@@ -22,7 +22,7 @@
   </fieldset>
 </div>
 
-<div class="form-group" data-show-when="defence_request_fit_for_interview_false">
+<div class="form-group panel-indent" data-show-when="defence_request_fit_for_interview_false">
   <%= f.label :unfit_for_interview_reason, label_text_for_form(attribute_name: 'unfit_for_interview_reason'), class: "form-label-bold" %>
   <%= f.text_area :unfit_for_interview_reason, label: t('unfit_for_interview_reason'), rows: '5', class: 'text-field text-field-wide' %>
 </div>

--- a/app/views/defence_requests/form_partials/_detainee_details.html.erb
+++ b/app/views/defence_requests/form_partials/_detainee_details.html.erb
@@ -49,8 +49,17 @@
 </div>
 
 <div class="form-group" data-show-when="defence_request_appropriate_adult_true">
-  <%= f.label :appropriate_adult_reason, label_text_for_form(attribute_name: 'appropriate_adult_reason'), class: "form-label-bold" %>
-  <%= f.text_area :appropriate_adult_reason, label: t('appropriate_adult_reason'), rows: '5', class: 'text-field text-field-wide' %>
+  <fieldset class="inline">
+    <%= f.label :appropriate_adult_reason, label_text_for_form(attribute_name: 'appropriate_adult_reason'), class: "form-label-bold" %>
+    <label class="block-label form-label" for="defence_request_appropriate_adult_reason_detainee_juvenile">
+      <%= f.radio_button :appropriate_adult_reason, :detainee_juvenile, name: 'defence_request[appropriate_adult_reason]' %>
+      <%= t('detainee_juvenile') %>
+    </label>
+    <label class="block-label form-label" for="defence_request_appropriate_adult_reason_detainee_with_mental_issue">
+      <%= f.radio_button :appropriate_adult_reason, :detainee_with_mental_issue, name: 'defence_request[appropriate_adult_reason]' %>
+      <%= t('detainee_with_mental_issue') %>
+    </label>
+  </fieldset>
 </div>
 
 <div class="form-group">

--- a/app/views/defence_requests/form_partials/_detainee_details.html.erb
+++ b/app/views/defence_requests/form_partials/_detainee_details.html.erb
@@ -48,9 +48,9 @@
   </fieldset>
 </div>
 
-<div class="form-group" data-show-when="defence_request_appropriate_adult_true">
+<div class="form-group panel-indent" data-show-when="defence_request_appropriate_adult_true">
   <fieldset class="inline">
-    <%= f.label :appropriate_adult_reason, label_text_for_form(attribute_name: 'appropriate_adult_reason'), class: "form-label-bold" %>
+    <%= f.label :appropriate_adult_reason, label_text_for_form(attribute_name: 'appropriate_adult_reason') + ":", class: "form-label-bold" %>
     <label class="block-label form-label" for="defence_request_appropriate_adult_reason_detainee_juvenile">
       <%= f.radio_button :appropriate_adult_reason, :detainee_juvenile, name: 'defence_request[appropriate_adult_reason]' %>
       <%= t('detainee_juvenile') %>
@@ -77,7 +77,7 @@
     </label>
   </fieldset>
 </div>
-<div class="form-group" data-show-when="defence_request_interpreter_required_true">
+<div class="form-group panel-indent" data-show-when="defence_request_interpreter_required_true">
   <%= f.label :interpreter_type, label_text_for_form(attribute_name: 'interpreter_type'), class: "form-label-bold" %>
   <%= f.text_field :interpreter_type, class: 'text-field text-field-wide' %>
 </div>

--- a/app/views/defence_requests/show_partials/_detainee_details.html.erb
+++ b/app/views/defence_requests/show_partials/_detainee_details.html.erb
@@ -3,7 +3,7 @@
   <%= display_value "date_of_birth", date_not_given_formatter(@defence_request, :date_of_birth) %>
 
   <%= display_value "appropriate_adult_required",
-                    boolean_with_explanation(@defence_request.appropriate_adult, true, @defence_request.appropriate_adult_reason)
+                    boolean_with_explanation(@defence_request.appropriate_adult, true, appropriate_adult_reason(@defence_request))
   %>
 
   <%= display_value "detainee_address", not_given_formatter(@defence_request, :detainee_address) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
   <%= render 'shared/ga' %>
 <% end %>
 <%= content_for :cookie_message, "" %>
-<%= content_for :js_gt_ie, '6' %>
+<%= content_for :js_gt_ie, '5' %>
 <%# TODO: convert banner to i18n? %>
 <% content_for :content_override do %>
   <main id="page-container" role="main">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,8 +56,10 @@ en:
   detainee_address: "Address"
   detainee_details: "Detainee details"
   detainee_dob: "Detainee date of birth"
+  detainee_juvenile: A juvenile
   detainee_name: "Detainee name"
   detention_details: "Detention details"
+  detainee_with_mental_issue: Mentally disturbed or mentally vunerable
   dscc: "DSCC"
   dscc_number: "DSCC number"
   edit: Edit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,8 +12,8 @@ en:
   add_expected_time_of_arrival: Estimate time of arrival
   add_interview_start_time: "Add Interview Start Time"
   adult: "Adult?"
-  appropriate_adult: Appropriate adult
-  appropriate_adult_reason: "Reason for appropriate adult"
+  appropriate_adult: Is an appropriate adult needed?
+  appropriate_adult_reason: "Because the detainee is"
   appropriate_adult_required: Appropriate adult required
   arrival_time: "Arrival time"
   arrival_time_cancel: "Cancel"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,7 @@ en:
   transgender: Transgender
   transition_info: Reason aborted
   unavailable: "Unavailable"
-  unfit_for_interview_reason: Reason unfit for interview
+  unfit_for_interview_reason: Reason
   update: "Update"
   update_and_accept: "Update and Accept"
   update_from: "Update from"

--- a/db/migrate/20150603092752_change_appropriate_adult_reason_to_string.rb
+++ b/db/migrate/20150603092752_change_appropriate_adult_reason_to_string.rb
@@ -1,0 +1,5 @@
+class ChangeAppropriateAdultReasonToString < ActiveRecord::Migration
+  def change
+    change_column :defence_requests, :appropriate_adult_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150602155851) do
+ActiveRecord::Schema.define(version: 20150603092752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 20150602155851) do
     t.datetime "interview_start_time"
     t.datetime "solicitor_time_of_arrival"
     t.text     "reason_aborted"
-    t.text     "appropriate_adult_reason"
+    t.string   "appropriate_adult_reason"
     t.string   "investigating_officer_name"
     t.string   "investigating_officer_contact_number"
     t.text     "circumstances_of_arrest"

--- a/spec/factories/defence_request.rb
+++ b/spec/factories/defence_request.rb
@@ -66,7 +66,7 @@ FactoryGirl.define do
 
   trait :appropriate_adult do
     appropriate_adult true
-    appropriate_adult_reason "They look underage"
+    appropriate_adult_reason "detainee_juvenile"
   end
 
   trait :interview_start_time do

--- a/spec/features/cso/creating_defence_request_spec.rb
+++ b/spec/features/cso/creating_defence_request_spec.rb
@@ -61,13 +61,15 @@ RSpec.feature "Custody Suite Officers creating defence requests" do
 
   specify "appropriate_adult toggles appropriate_adult_reason", js: true do
     login_and_open_new_defence_request_page
-
+    fill_in_defence_request_form
     within ".detainee" do
       choose "defence_request_appropriate_adult_true"
+      choose "defence_request_appropriate_adult_reason_detainee_juvenile"
     end
-
-    expect(page).
-      to_not have_css "#defence_request_appropriate_adult_reason[disabled]"
+    click_button "Create Defence Request"
+    save_and_open_page
+    expect(page).to have_content "Check the request"
+    expect(page).to have_content "Yes – because the detainee is a juvenile"
   end
 
   specify "is prompted to check the request after successfully filling in the form" do

--- a/spec/features/cso/creating_defence_request_spec.rb
+++ b/spec/features/cso/creating_defence_request_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature "Custody Suite Officers creating defence requests" do
       choose "defence_request_appropriate_adult_reason_detainee_juvenile"
     end
     click_button "Create Defence Request"
-    save_and_open_page
+
     expect(page).to have_content "Check the request"
     expect(page).to have_content "Yes – because the detainee is a juvenile"
   end

--- a/spec/models/defence_request_spec.rb
+++ b/spec/models/defence_request_spec.rb
@@ -17,6 +17,29 @@ RSpec.describe DefenceRequest, type: :model do
         subject.appropriate_adult = true
       end
       it { expect(subject).to validate_presence_of :appropriate_adult_reason }
+
+      context "with invalid reason value" do
+        before do
+          subject.appropriate_adult_reason = "bad value"
+          subject.validate
+        end
+        it { expect(subject.errors[:appropriate_adult_reason].size).to eq(1) }
+      end
+
+      context "with detainee_juvenile value" do
+        before do
+          subject.appropriate_adult_reason = "detainee_juvenile"
+          subject.validate
+        end
+        it { expect(subject.errors[:appropriate_adult_reason]).to be_blank }
+      end
+      context "with detainee_with_mental_issue value" do
+        before do
+          subject.appropriate_adult_reason = "detainee_with_mental_issue"
+          subject.validate
+        end
+        it { expect(subject.errors[:appropriate_adult_reason]).to be_blank }
+      end
     end
 
     context "appropriate_adult_reason not required" do

--- a/spec/models/defence_request_spec.rb
+++ b/spec/models/defence_request_spec.rb
@@ -17,28 +17,9 @@ RSpec.describe DefenceRequest, type: :model do
         subject.appropriate_adult = true
       end
       it { expect(subject).to validate_presence_of :appropriate_adult_reason }
-
-      context "with invalid reason value" do
-        before do
-          subject.appropriate_adult_reason = "bad value"
-          subject.validate
-        end
-        it { expect(subject.errors[:appropriate_adult_reason].size).to eq(1) }
-      end
-
-      context "with detainee_juvenile value" do
-        before do
-          subject.appropriate_adult_reason = "detainee_juvenile"
-          subject.validate
-        end
-        it { expect(subject.errors[:appropriate_adult_reason]).to be_blank }
-      end
-      context "with detainee_with_mental_issue value" do
-        before do
-          subject.appropriate_adult_reason = "detainee_with_mental_issue"
-          subject.validate
-        end
-        it { expect(subject.errors[:appropriate_adult_reason]).to be_blank }
+      it do
+        valid_values = %w(detainee_juvenile detainee_with_mental_issue)
+        expect(subject).to validate_inclusion_of(:appropriate_adult_reason).in_array(valid_values)
       end
     end
 

--- a/spec/support/features/defence_request_helpers.rb
+++ b/spec/support/features/defence_request_helpers.rb
@@ -22,7 +22,7 @@ module DefenceRequestHelpers
         fill_in "defence_request_interview_start_time_min", with: "01"
       end
       within ".detainee" do
-        fill_in "Full Name", with: "Mannie Badder"
+        fill_in "defence_request_detainee_name", with: "Mannie Badder"
       end
     else
       within ".case-details" do


### PR DESCRIPTION
* Change appropriate adult reason input to radio buttons.
* Change `appropriate_adult_reason` from text to string.
* Validate `appropriate_adult_reason` is a valid locales key value.
* Implements story: https://www.pivotaltracker.com/story/show/93690592
* Enable javascript for IE 6.
* Tested show/hide javascript on IE 6/7. Worked ok.