### PR TITLE
Make whole defence request row clickable for cso

### DIFF
--- a/app/assets/javascripts/page_initialise.coffee
+++ b/app/assets/javascripts/page_initialise.coffee
@@ -9,4 +9,9 @@ jQuery ->
   $("form [data-disable-when]").each ->
     new window.DisableChecker($(this))
 
+  $("table tr.clickable-row").each ->
+    $(this).addClass("clickable-row-active")
+    $(this).on "click", ->
+      window.location = $(this).data("link")
+
   return

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -156,6 +156,10 @@ table.dashboard {
       }
     }
   }
+  
+  .clickable-row-active {
+    cursor: pointer;
+  }
 
   .grey {
     background: $grey-4

--- a/app/views/defence_requests/_cso.html.erb
+++ b/app/views/defence_requests/_cso.html.erb
@@ -11,7 +11,7 @@
 
   <tbody>
     <% requests.each_with_index do |dr,i| %>
-      <%= content_tag_for(:tr, dr, class: "cso-dashboard-dr #{cycle("", "grey")}") do %>
+      <%= content_tag_for(:tr, dr, class: "cso-dashboard-dr #{cycle("", "grey")} clickable-row", "data-link": defence_request_path(dr)) do %>
         <td class="detainee">
           <div class="detainee-container <%= dr.state_class %>">
             <p class="name"><%= dr.detainee_name %></p>


### PR DESCRIPTION
I implemented it as a progressive enhancement using JS, rather then wrapping the whole row in a `<a>`. Because for assistive technology the content of that link wouldn't make any sense. Also I'm not sure about having that much content in a link if that's valid. 