### PR TITLE
Update GOV.UK elements CSS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem "unicorn", "~> 4.8.3"
 # MOJ styles
 gem "moj_template", "~> 0.23.0"
 gem "govuk_frontend_toolkit", "~> 3.4.2"
-gem "govuk_elements_rails", "~> 0.1.1"
+gem "govuk_elements_rails", "~> 0.3.0"
 
 group :development do
   gem "guard-rspec", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     formatador (0.2.5)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
-    govuk_elements_rails (0.1.1)
+    govuk_elements_rails (0.3.0)
       rails (~> 4.1, >= 4.1.0)
       sass (~> 3.2, >= 3.2.0)
     govuk_frontend_toolkit (3.4.2)
@@ -387,7 +387,7 @@ DEPENDENCIES
   drs-auth_client!
   factory_girl_rails
   faker (~> 1.4.3)
-  govuk_elements_rails (~> 0.1.1)
+  govuk_elements_rails (~> 0.3.0)
   govuk_frontend_toolkit (~> 3.4.2)
   guard-jasmine!
   guard-rspec

--- a/app/assets/stylesheets/govuk_elements_extensions.scss
+++ b/app/assets/stylesheets/govuk_elements_extensions.scss
@@ -15,6 +15,10 @@ $path: "";
 
 $disable-background: #eee;
 
+#page-container {
+  @extend %site-width-container;
+}
+
 h1 {
   @extend .heading-xlarge;
   margin-right: 6%;
@@ -81,7 +85,7 @@ fieldset, .sub-panel {
 }
 
 .alert-summary {
-  @extend .validation-summary;
+  @extend .error-summary;
   border: 3px solid $red;
   h3 {
     margin-top: 10px;
@@ -89,7 +93,7 @@ fieldset, .sub-panel {
 }
 
 .notice-summary {
-  @extend .validation-summary;
+  @extend .error-summary;
   border: 3px solid $green;
   h3 {
     margin-top: 10px;
@@ -97,7 +101,7 @@ fieldset, .sub-panel {
 }
 
 .success-summary {
-  @extend .validation-summary;
+  @extend .error-summary;
   border: 3px solid $green;
   h3 {
     margin-top: 10px;
@@ -105,7 +109,7 @@ fieldset, .sub-panel {
 }
 
 span.error {
-  @extend .validation-message;
+  @extend .error-message;
 }
 
 .js-enabled {

--- a/app/assets/stylesheets/tabs.scss
+++ b/app/assets/stylesheets/tabs.scss
@@ -66,6 +66,8 @@ ul.tabs {
   width: 100%;
   list-style: none;
   margin-left: 0;
+  padding: 0;
+
   li {
     @include media(mobile) {
       @include grid-column(1 / 2, $full_width: mobile);


### PR DESCRIPTION
* Update `govuk_elements_rails` gem version to pick up new error validation styles.
* Minor changes to css to make compatible with latest GOV.UK elements styles.
* For a description of the new styles see:  https://govuk-elements.herokuapp.com/snippets/#guide-errors