### PR TITLE
Update cso form and details view with content tweaks

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -2,6 +2,10 @@
 @import "elements/elements-typography";
 @import "grid_layout";
 
+.new_defence_request {
+  margin-top: 3em;
+}
+
 table.dashboard {
   width: 100%;
   th { font-size: 15px; }
@@ -156,7 +160,7 @@ table.dashboard {
       }
     }
   }
-  
+
   .clickable-row-active {
     cursor: pointer;
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,7 +67,7 @@ module ApplicationHelper
   end
 
   def boolean_with_explanation(val, explanation_when, explanation)
-    reason = (" #{explanation}" if val == explanation_when) || ""
+    reason = (" – #{explanation}" if val == explanation_when) || ""
     boolean_formatter(val) + reason
   end
 end

--- a/app/helpers/defence_requests_helper.rb
+++ b/app/helpers/defence_requests_helper.rb
@@ -86,7 +86,7 @@ module DefenceRequestsHelper
   def appropriate_adult_reason(defence_request)
     if defence_request.appropriate_adult?
       reason = t(defence_request.appropriate_adult_reason).downcase
-      ["–", t("appropriate_adult_reason").downcase, reason].join(" ")
+      [t("appropriate_adult_reason").downcase, reason].join(" ")
     else
       ""
     end

--- a/app/views/dashboards/_dashboard.html.erb
+++ b/app/views/dashboards/_dashboard.html.erb
@@ -4,8 +4,6 @@
 
 <%= flash_messages %>
 
-<h1></h1>
-
 <% if check_policy_clause(@policy, :create?) %>
   <div class="new_defence_request">
     <%= link_to t("new_request"), new_defence_request_path, role: "button", class: "button" %>

--- a/app/views/dashboards/_dashboard.html.erb
+++ b/app/views/dashboards/_dashboard.html.erb
@@ -4,7 +4,7 @@
 
 <%= flash_messages %>
 
-<h1><%= "#{t(@dashboard.user_role)}  #{t('dashboard')}" %></h1>
+<h1></h1>
 
 <% if check_policy_clause(@policy, :create?) %>
   <div class="new_defence_request">

--- a/app/views/defence_requests/form_partials/_case.html.erb
+++ b/app/views/defence_requests/form_partials/_case.html.erb
@@ -14,7 +14,7 @@
   <%= render('shared/date_time_form_part', attribute: :time_of_detention_authorised, show_label: true, set_default_date: true, f: f) %>
 
   <% if @policy.interview_start_time_edit? %>
-    <%= render('shared/date_time_form_part', attribute: :interview_start_time, show_label: true, optional: true, set_default_date: false, f: f) %>
+    <%= render('shared/date_time_form_part', attribute: :interview_start_time, show_label: true, optional: true, hint_label: :interview_start_time_hint , set_default_date: false, f: f) %>
   <% end %>
 
   <%= render('defence_requests/form_partials/case_details', f: f) if @policy.create? %>

--- a/app/views/defence_requests/form_partials/_case.html.erb
+++ b/app/views/defence_requests/form_partials/_case.html.erb
@@ -1,5 +1,10 @@
 <h2><%= t('case_details') %></h2>
 <div class="case-details">
+  <div class="form-group">
+    <%= f.label :custody_number, label_text_for_form(attribute_name: 'custody_number'), class: "form-label-bold" %>
+    <%= f.text_field :custody_number, label: t('custody_number'), class: 'text-field' %>
+  </div>
+
   <%= render('shared/date_time_form_part', attribute: :time_of_arrest, show_label: true, set_default_date: true, f: f) %>
 
   <% if @policy.add_case_time_of_arrival? %>
@@ -7,11 +12,6 @@
   <% end %>
 
   <%= render('shared/date_time_form_part', attribute: :time_of_detention_authorised, show_label: true, set_default_date: true, f: f) %>
-
-  <div class="form-group">
-    <%= f.label :custody_number, label_text_for_form(attribute_name: 'custody_number'), class: "form-label-bold" %>
-    <%= f.text_field :custody_number, label: t('custody_number'), class: 'text-field' %>
-  </div>
 
   <% if @policy.interview_start_time_edit? %>
     <%= render('shared/date_time_form_part', attribute: :interview_start_time, show_label: true, optional: true, set_default_date: false, f: f) %>

--- a/app/views/defence_requests/form_partials/_case_details.html.erb
+++ b/app/views/defence_requests/form_partials/_case_details.html.erb
@@ -10,7 +10,7 @@
 
 <div class="form-group">
   <fieldset class="inline">
-    <%= f.label :fit_for_interview, label_text_for_form(attribute_name: 'fit_for_interview') + "?", class: "form-label-bold" %>
+    <%= f.label :fit_for_interview, label_text_for_form(attribute_name: 'fit_for_interview_question'), class: "form-label-bold" %>
     <label class="block-label form-label" for="defence_request_fit_for_interview_true">
       <%= f.radio_button :fit_for_interview, true, name: 'defence_request[fit_for_interview]', class: 'fit_for_interview_radio' %>
       <%= t('yes') %>
@@ -23,8 +23,8 @@
 </div>
 
 <div class="form-group panel-indent" data-show-when="defence_request_fit_for_interview_false">
-  <%= f.label :unfit_for_interview_reason, label_text_for_form(attribute_name: 'unfit_for_interview_reason'), class: "form-label-bold" %>
-  <%= f.text_area :unfit_for_interview_reason, label: t('unfit_for_interview_reason'), rows: '5', class: 'text-field text-field-wide' %>
+  <%= f.label :unfit_for_interview_reason, label_text_for_form(attribute_name: 'unfit_for_interview_reasons'), class: "form-label-bold" %>
+  <%= f.text_area :unfit_for_interview_reason, rows: '5', class: 'text-field text-field-wide' %>
 </div>
 
 <div class="form-group">

--- a/app/views/defence_requests/form_partials/_detainee.html.erb
+++ b/app/views/defence_requests/form_partials/_detainee.html.erb
@@ -1,5 +1,5 @@
 <% if @policy.create? %>
-    <h2><%= t('detainee_details') %></h2>
+    <h2><%= t('detainee') %></h2>
     <div class="detainee">
       <%= render('defence_requests/form_partials/detainee_details', f: f) %>
     </div>

--- a/app/views/defence_requests/form_partials/_detainee_date_of_birth.html.erb
+++ b/app/views/defence_requests/form_partials/_detainee_date_of_birth.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <fieldset class="inline time-select">
     <label for>
-      <%= f.label :date_of_birth, label_text_for_form(attribute_name: 'detainee_dob'), class: 'form-label-bold' %>
+      <%= f.label :date_of_birth, label_text_for_form(attribute_name: 'date_of_birth'), class: 'form-label-bold' %>
       <span class='hint block'><%= t('date_hint') %></span>
     </label>
     <%= f.fields_for :date_of_birth, @defence_request_form.fields[:date_of_birth] do |t| %>

--- a/app/views/defence_requests/form_partials/_detainee_details.html.erb
+++ b/app/views/defence_requests/form_partials/_detainee_details.html.erb
@@ -11,22 +11,22 @@
 <div class="form-group">
   <fieldset class="inline">
     <%= f.label :gender, label_text_for_form(attribute_name: 'gender'), class: "form-label-bold" %>
-    <label class="block-label form-label" for="defence_request_gender_male">
+    <%= f.label :gender_male, class: "block-label form-label" do %>
       <%= f.radio_button :gender, :male, name: 'defence_request[gender]' %>
       <%= t('male') %>
-    </label>
-    <label class="block-label form-label" for="defence_request_gender_female">
+    <%- end %>
+    <%= f.label :gender_female, class: "block-label form-label" do %>
       <%= f.radio_button :gender, :female, name: 'defence_request[gender]' %>
       <%= t('female') %>
-    </label>
-    <label class="block-label form-label" for="defence_request_gender_transgender">
+    <%- end %>
+    <%= f.label :gender_transgender, class: "block-label form-label" do %>
       <%= f.radio_button :gender, :transgender, name: 'defence_request[gender]' %>
       <%= t('transgender') %>
-    </label>
-    <label class="block-label form-label" for="defence_request_gender_not_specified">
+    <%- end %>
+    <%= f.label :gender_unspecified, class: "block-label form-label" do %>
       <%= f.radio_button :gender, :unspecified, name: 'defence_request[gender]' %>
       <%= t('unspecified') %>
-    </label>
+    <%- end %>
   </fieldset>
 </div>
 

--- a/app/views/defence_requests/form_partials/_detainee_details.html.erb
+++ b/app/views/defence_requests/form_partials/_detainee_details.html.erb
@@ -1,5 +1,5 @@
 <div class="form-group">
-  <%= f.label :detainee_name, label_text_for_form(attribute_name: 'full_name'), class: "form-label-bold" %>
+  <%= f.label :detainee_name, label_text_for_form(attribute_name: 'name'), class: "form-label-bold" %>
   <%= f.text_field :detainee_name, class: 'text-field text-field-wide not-given-check',
                     data: { "disable-when" => "defence_request_detainee_name_not_given" } %>
   <%= f.label :detainee_name_not_given, class: 'form-checkbox' do %>
@@ -24,13 +24,23 @@
       <%= t('transgender') %>
     </label>
     <label class="block-label form-label" for="defence_request_gender_not_specified">
-      <%= f.radio_button :gender, :not_specified, name: 'defence_request[gender]' %>
-      <%= t('not_specified') %>
+      <%= f.radio_button :gender, :unspecified, name: 'defence_request[gender]' %>
+      <%= t('unspecified') %>
     </label>
   </fieldset>
 </div>
 
 <%= render('defence_requests/form_partials/detainee_date_of_birth', f: f) %>
+
+<div class="form-group">
+  <%= f.label :detainee_address, label_text_for_form(attribute_name: 'detainee_address'), class: "form-label-bold" %>
+  <%= f.text_field :detainee_address, class: 'text-field text-field-wide not-given-check',
+                    data: { "disable-when" => "defence_request_detainee_address_not_given" } %>
+  <%= f.label :detainee_address_not_given, class: 'form-checkbox' do %>
+    <%= f.check_box :detainee_address_not_given %>
+    <%= t("not_given") -%>
+  <% end %>
+</div>
 
 <div class="form-group">
   <fieldset class="inline">
@@ -64,7 +74,7 @@
 
 <div class="form-group">
   <fieldset class="inline">
-    <%= f.label :interpreter_required, label_text_for_form(attribute_name: 'interpreter_required'), class: "form-label-bold" %>
+    <%= f.label :interpreter_required, label_text_for_form(attribute_name: 'interpreter_required_question'), class: "form-label-bold" %>
     <label class="block-label form-label" for="defence_request_interpreter_required_true">
       <%= f.radio_button :interpreter_required, true, name: 'defence_request[interpreter_required]',
                          class: 'interpreter_required_radio' %>
@@ -80,14 +90,4 @@
 <div class="form-group panel-indent" data-show-when="defence_request_interpreter_required_true">
   <%= f.label :interpreter_type, label_text_for_form(attribute_name: 'interpreter_type'), class: "form-label-bold" %>
   <%= f.text_field :interpreter_type, class: 'text-field text-field-wide' %>
-</div>
-
-<div class="form-group">
-  <%= f.label :detainee_address, label_text_for_form(attribute_name: 'detainee_address'), class: "form-label-bold" %>
-  <%= f.text_field :detainee_address, class: 'text-field text-field-wide not-given-check',
-                    data: { "disable-when" => "defence_request_detainee_address_not_given" } %>
-  <%= f.label :detainee_address_not_given, class: 'form-checkbox' do %>
-    <%= f.check_box :detainee_address_not_given %>
-    <%= t("not_given") -%>
-  <% end %>
 </div>

--- a/app/views/defence_requests/form_partials/_form_actions.html.erb
+++ b/app/views/defence_requests/form_partials/_form_actions.html.erb
@@ -1,5 +1,5 @@
 <% if @defence_request_form.defence_request.new_record? %>
-  <%= f.submit class: 'button' %>
+  <%= f.submit t("create_request"), class: 'button' %>
   <div class="form-links">
     <%= link_to t('cancel_and_delete_all_details'), dashboard_path %>
   </div>

--- a/app/views/defence_requests/show.html.erb
+++ b/app/views/defence_requests/show.html.erb
@@ -18,10 +18,10 @@
 <%= content_tag("div", class: "js-tabs", id: "edit-tabs", data: { activatefirst: "true" }) do %>
   <ul class="cf tabs js-tabs-nav js-only">
     <li>
-      <a href="#interview">Interview</a>
+      <a href="#interview"><%= t("solicitor_attendance") %></a>
     </li>
     <li>
-      <a href="#case-details"><%= t("detention_details") %></a>
+      <a href="#case-details"><%= t("case_details") %></a>
     </li>
     <li class="filler">
     </li>
@@ -31,7 +31,7 @@
       <%= render "defence_requests/show_partials/interview_tab" %>
     </div>
     <div id="case-details">
-      <h3 class="nonjs"><%= t("detention_details")%></h3>
+      <h3 class="nonjs"><%= t("case_details")%></h3>
       <%= render "defence_requests/show_partials/detention_details" %>
     </div>
   </div>

--- a/app/views/defence_requests/show_draft.html.erb
+++ b/app/views/defence_requests/show_draft.html.erb
@@ -1,7 +1,7 @@
 <h1>Check the request</h1>
 
-<p>Check the details below to make sure they are correct. Update any incorrect details, then submit the request.</p>
-
+<p>Check the details below to make sure they're correct. You can change any incorrect details and save changes. Then submit the request.</p>
+<p>You can edit the request later if there's updates for further information to add.</p>
 <section class="detainee-details">
   <h2><%= not_given_formatter(@defence_request, :detainee_name, "name_not_given") %></h2>
 
@@ -12,7 +12,7 @@
 
 
 <section class="detention-details">
-  <h2 class="line-above">Detention Details</h2>
+  <h2 class="line-above"><%= t("case_details") %></h2>
 
   <%= render("defence_requests/show_partials/detention_details") %>
 

--- a/app/views/defence_requests/show_partials/_detainee_details.html.erb
+++ b/app/views/defence_requests/show_partials/_detainee_details.html.erb
@@ -2,11 +2,13 @@
   <%= display_value "gender", t(@defence_request.gender) %>
   <%= display_value "date_of_birth", date_not_given_formatter(@defence_request, :date_of_birth) %>
 
+  <%= display_value "detainee_address", not_given_formatter(@defence_request, :detainee_address) %>
+
   <%= display_value "appropriate_adult_required",
                     boolean_with_explanation(@defence_request.appropriate_adult, true, appropriate_adult_reason(@defence_request))
   %>
 
-  <%= display_value "detainee_address", not_given_formatter(@defence_request, :detainee_address) %>
+
 
   <%= display_value "interpreter_required",
                     boolean_with_explanation(@defence_request.interpreter_required, true, @defence_request.interpreter_type)

--- a/app/views/defence_requests/show_partials/_detention_details.html.erb
+++ b/app/views/defence_requests/show_partials/_detention_details.html.erb
@@ -1,8 +1,9 @@
 <dl class="labels">
+  <%= display_value "custody_number", @defence_request.custody_number %>
   <%= display_value "time_of_arrest", date_and_time_formatter(@defence_request.time_of_arrest) %>
   <%= display_value "time_of_arrival", date_and_time_formatter(@defence_request.time_of_arrival) %>
   <%= display_value "time_of_detention_authorised", date_and_time_formatter(@defence_request.time_of_detention_authorised) %>
-  <%= display_value "custody_number", @defence_request.custody_number %>
+
   <%= display_value "offences", @defence_request.offences %>
   <%= display_value "circumstances_of_arrest", @defence_request.circumstances_of_arrest %>
   <%= display_value "fit_for_interview",

--- a/app/views/defence_requests/show_partials/_interview_tab.html.erb
+++ b/app/views/defence_requests/show_partials/_interview_tab.html.erb
@@ -1,6 +1,7 @@
 <% if @policy.interview_start_time_edit? %>
   <h3><%= t("interview_planning") %></h3>
-  <p><span class="hint"><%= t("interview_planning_help") %></span></p>
+  <span class="hint"><%= t("interview_planning_help") %></span>
+  <span class='hint block'><%= t('time_hint') %></span>
   <%= form_for(@defence_request, url: defence_request_interview_start_time_path(defence_request_id: @defence_request.id), method: :patch) do |f| %>
     <%= render("shared/date_time_form_part", attribute: :interview_start_time, show_label: false, set_default_date: false, f: f) %>
     <%= f.submit(t("add_interview_start_time"), class: "button") %>
@@ -21,6 +22,7 @@
   <% end %>
 <% end %>
 
+<% if false # disabled for CSO testing. Only show this content to Solicitors %>
 <div class="location">
   <h3>Location</h3>
   <p>This is a made up address because it's not implemented <%= link_to "XX9 9XX", "X" %></p>
@@ -34,3 +36,4 @@
   <%= display_value "investigating_officer_name", @defence_request.investigating_officer_name %>
   <%= display_value "investigating_officer_contact_number", @defence_request.investigating_officer_contact_number %>
 </dl>
+<% end %>

--- a/app/views/shared/_date_time_form_part.html.erb
+++ b/app/views/shared/_date_time_form_part.html.erb
@@ -4,6 +4,7 @@
     <%- if local_assigns.fetch(:show_label, false) %>
       <label for>
         <%= f.label attribute, label_text_for_form(attribute_name: attribute, optional: local_assigns.fetch(:optional, false)), class: 'form-label-bold' %>
+        <span class='hint block'><%= t('time_hint') %></span>
       </label>
     <%- end %>
     <%= f.fields_for attribute, @defence_request_form.fields[attribute] do |t| %>

--- a/app/views/shared/_date_time_form_part.html.erb
+++ b/app/views/shared/_date_time_form_part.html.erb
@@ -2,14 +2,12 @@
 <div class="form-group">
   <fieldset class="inline time-select date-chooser">
     <%- if local_assigns.fetch(:show_label, false) %>
-      <label for>
         <%= f.label attribute, label_text_for_form(attribute_name: attribute, optional: local_assigns.fetch(:optional, false)), class: 'form-label-bold' %>
 
         <%- if local_assigns.fetch(:hint_label, false) %>
           <span class='hint block'><%= t(hint_label) %></span>
         <%- end %>
         <span class='hint block'><%= t('time_hint') %></span>
-      </label>
     <%- end %>
     <%= f.fields_for attribute, @defence_request_form.fields[attribute] do |t| %>
       <div class="date-field-wrapper">

--- a/app/views/shared/_date_time_form_part.html.erb
+++ b/app/views/shared/_date_time_form_part.html.erb
@@ -4,6 +4,10 @@
     <%- if local_assigns.fetch(:show_label, false) %>
       <label for>
         <%= f.label attribute, label_text_for_form(attribute_name: attribute, optional: local_assigns.fetch(:optional, false)), class: 'form-label-bold' %>
+
+        <%- if local_assigns.fetch(:hint_label, false) %>
+          <span class='hint block'><%= t(hint_label) %></span>
+        <%- end %>
         <span class='hint block'><%= t('time_hint') %></span>
       </label>
     <%- end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
   actions: "Actions"
   active: "Active (%{count})"
   add_expected_time_of_arrival: Estimate time of arrival
-  add_interview_start_time: "Add Interview Start Time"
+  add_interview_start_time: "Save interview time"
   adult: "Adult?"
   appropriate_adult: Is an appropriate adult needed?
   appropriate_adult_reason: "Because the detainee is"
@@ -26,14 +26,14 @@ en:
   cancel: "Cancel"
   cancel_and_delete_all_details: "Cancel and delete all details"
   case_aborted: "This case has been aborted for the following reason"
-  case_details: "Case Details"
-  case_details_for: "Case Details for %{dscc}"
+  case_details: "Case details"
+  case_details_for: "Case details for %{dscc}"
   cco: "Call Center Operative"
   change_password: "Change Password"
   circumstances_of_arrest: Circumstances of arrest
   closed: "Closed (%{count})"
   comments: "Comments"
-  comments_field_aside_text: "E.g samples required, Section 18 House Search or full medical examination"
+  comments_field_aside_text: "eg samples required, Section 18 House Search or full medical examination"
   complete: Complete
   completed: "Completed (%{count})"
   confirm: "Confirm"
@@ -41,13 +41,14 @@ en:
   continue: "Continue"
   cookies: "Cookies"
   cso: "Custody Suite Officer"
+  create_request: "Create request"
   custody_address: Custody Address
   custody_number: "Custody number"
   custody_number_prefix: "CN:"
   custody_phone_number: "Custody Phone Number"
-  dashboard: 'Dashboard'
-  date_hint: "eg. 28 04 1996"
-  date_of_birth: "Date of Birth"
+  dashboard: 'dashboard'
+  date_hint: "eg 28 04 1996"
+  date_of_birth: "Date of birth"
   date_time_hint: "eg. 28 04 1996 - 11 30"
   day: "Day"
   delete: "Delete"
@@ -70,13 +71,15 @@ en:
   expected_time_of_arrival: "Solicitor Time of Arrival"
   expired: "Session expired"
   female: "Female"
-  fit_for_interview: Is detainee fit for interview
+  fit_for_interview: Fit for interview
+  fit_for_interview_question: Is the detainee fit for interview?
   full_name: "Full Name"
   gender: "Gender"
   help: "Help"
   home: "Home"
   hour: "Hour"
   interpreter_required: Interpreter required
+  interpreter_required_question: Is an interpreter required?
   interpreter_type: Interpreter type
   interview: "Interview"
   interview_at: "Interview at"
@@ -92,15 +95,15 @@ en:
   male: "Male"
   min: "Min"
   month: "Month"
+  name: "Name"
   name_not_given: "Name not given"
   name_of_firm: "Name of firm"
-  new_defence_requests: "New Defence Requests"
-  new_defence_request: "New Defence Request"
+  new_defence_requests: "New defence requests"
+  new_defence_request: "New defence request"
   new_request: "New request"
   no_results_found: 'No results found - Contact DSCC'
   not_authorized: "You are not authorised to perform this action"
-  not_given: "not given"
-  not_specified: "Not specified"
+  not_given: "Not given"
   offences: "Offences"
   optional: "optional"
   pending: pending
@@ -115,6 +118,7 @@ en:
   show: "Show"
   sign_out: "Sign out"
   solicitor: "Solicitor"
+  solicitor_attendance: "Solicitor attendance"
   solicitor_details: "Solicitor details"
   solicitor_email: "Solicitor Email"
   solicitor_email: "Solicitor Email"
@@ -126,19 +130,20 @@ en:
   telephone_number: "Telephone number"
   terms: "Terms"
   terms_and_conditions: "Terms and conditions and privacy policy"
-  time_hint: "eg. 23 10"
-  time_of_arrest: Arrest time
+  time_hint: "eg 23 10"
+  time_of_arrest: "Arrest time "
   time_of_arrival: Arrival time
   time_of_detention_authorised: Detention authorised time
   today: Today
   transgender: Transgender
   transition_info: Reason aborted
   unavailable: "Unavailable"
-  unfit_for_interview_reason: Reason
+  unfit_for_interview_reasons: Reasons
   update: "Update"
   update_and_accept: "Update and Accept"
   update_from: "Update from"
   update_time_of_arrival: "Update time of arrival"
+  unspecified: "Unspecified"
   view_the_case_details: "View the case details"
   what_type_is_being_requested: "What type of solicitor is being requested?"
   year: "Year"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,7 @@ en:
   interview_start_time: Interview start time
   interview_start_time_change: "Interview start time change"
   interview_time: Interview time
+  interview_start_time_hint: "Add the interview time now, if you know it, or update the request later when you have this information"
   investigating_officer_contact_number: Investigating officer contact number
   investigating_officer_name: Investigating officer name
   investigating_officer_shoulder_number: Investigating officer shoulder number

--- a/spec/features/cso/checking_and_submitting_defence_request_spec.rb
+++ b/spec/features/cso/checking_and_submitting_defence_request_spec.rb
@@ -50,6 +50,6 @@ RSpec.feature "Custody Suite Officers checking and submitting defence requests" 
 
     click_link "New request"
     fill_in_defence_request_form
-    click_button "Create Defence Request"
+    click_button "Create request"
   end
 end

--- a/spec/features/cso/creating_defence_request_spec.rb
+++ b/spec/features/cso/creating_defence_request_spec.rb
@@ -4,12 +4,12 @@ RSpec.feature "Custody Suite Officers creating defence requests" do
   specify "creating a blank defence request displays all required validation errors" do
     login_and_open_new_defence_request_page
 
-    click_button "Create Defence Request"
+    click_button "Create request"
 
     expect(current_path).to eq("/defence_requests")
     expect(page).to have_content "You need to fix the errors on this page before continuing"
 
-    ["Detainee name", "Address", "Date of Birth", "Offences", "Custody number", "Gender"].each do |field_name|
+    ["Detainee name", "Address", "Date of birth", "Offences", "Custody number", "Gender"].each do |field_name|
       expect(page).to have_css(".error-summary li", text: "#{field_name}: can't be blank")
     end
   end
@@ -17,11 +17,11 @@ RSpec.feature "Custody Suite Officers creating defence requests" do
   specify "can select \"not specified\" for gender" do
     login_and_open_new_defence_request_page
 
-    fill_in_defence_request_form gender: "Not specified"
+    fill_in_defence_request_form gender: "Unspecified"
 
-    click_button "Create Defence Request"
+    click_button "Create request"
 
-    expect(page).to have_css("dl.labels dd", text: "Not specified")
+    expect(page).to have_css("dl.labels dd", text: "Unspecified")
   end
 
   specify "can select \"transgender\" for gender" do
@@ -29,7 +29,7 @@ RSpec.feature "Custody Suite Officers creating defence requests" do
 
     fill_in_defence_request_form gender: "Transgender"
 
-    click_button "Create Defence Request"
+    click_button "Create request"
 
     expect(page).to have_css("dl.labels dd", text: "Transgender")
   end
@@ -39,10 +39,10 @@ RSpec.feature "Custody Suite Officers creating defence requests" do
 
     fill_in_defence_request_form not_given: true
 
-    click_button "Create Defence Request"
+    click_button "Create request"
 
     expect(page).to have_css("h2", text: "Name not given")
-    expect(page).to have_css("dl.labels dd", text: "not given", count: 2)
+    expect(page).to have_css("dl.labels dd", text: "Not given", count: 2)
   end
 
   #Fixme this test doesn't do what it says
@@ -50,7 +50,7 @@ RSpec.feature "Custody Suite Officers creating defence requests" do
     login_and_open_new_defence_request_page
 
     fill_in_defence_request_form
-    click_button "Create Defence Request"
+    click_button "Create request"
   end
 
   specify "can not see the solicitor time of arrival field on the defence request form" do
@@ -66,7 +66,7 @@ RSpec.feature "Custody Suite Officers creating defence requests" do
       choose "defence_request_appropriate_adult_true"
       choose "defence_request_appropriate_adult_reason_detainee_juvenile"
     end
-    click_button "Create Defence Request"
+    click_button "Create request"
 
     expect(page).to have_content "Check the request"
     expect(page).to have_content "Yes – because the detainee is a juvenile"
@@ -76,7 +76,7 @@ RSpec.feature "Custody Suite Officers creating defence requests" do
     login_and_open_new_defence_request_page
 
     fill_in_defence_request_form
-    click_button "Create Defence Request"
+    click_button "Create request"
 
     expect(page).to have_css("h1", "Check the request")
   end

--- a/spec/features/cso/defence_request_management_spec.rb
+++ b/spec/features/cso/defence_request_management_spec.rb
@@ -150,7 +150,7 @@ RSpec.feature "Custody Suite Officers managing defence requests" do
           click_link "❭"
 
           click_link "< Back to requests"
-          expect(page).to have_content "Custody Suite Officer Dashboard"
+          expect(current_path).to eq("/dashboard")
         end
       end
     end

--- a/spec/features/solicitor/defence_request_management_spec.rb
+++ b/spec/features/solicitor/defence_request_management_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Solicitors managing defence requests" do
 
     specify "can see the show page of the request", :mock_auth_api do
       login_with solicitor_user
-      click_link "Case Details for #{accepted_defence_request.dscc_number}"
+      click_link "Case details for #{accepted_defence_request.dscc_number}"
 
       expect(page).to have_content accepted_defence_request.dscc_number
       expect(page).to have_content accepted_defence_request.detainee_name
@@ -46,7 +46,7 @@ RSpec.feature "Solicitors managing defence requests" do
 
     specify "can edit the expected arrival time from the show page of the request", :mock_auth_api do
       login_with solicitor_user
-      click_link "Case Details for #{accepted_defence_request.dscc_number}"
+      click_link "Case details for #{accepted_defence_request.dscc_number}"
       click_link "Estimate time of arrival"
 
       expect(page).to have_css ".date-chooser-select.js-only"
@@ -69,7 +69,7 @@ RSpec.feature "Solicitors managing defence requests" do
 
     specify "can edit the expected arrival time from the show page of the request with JS enabled", :mock_auth_api, js: true do
       login_with solicitor_user
-      click_link "Case Details for #{accepted_defence_request.dscc_number}"
+      click_link "Case details for #{accepted_defence_request.dscc_number}"
       click_link "Estimate time of arrival"
       enter_time hour: "23", min: "02"
       click_button "Save"
@@ -104,7 +104,7 @@ RSpec.feature "Solicitors managing defence requests" do
 
     specify "are shown a message if the time of arrival cannot be updated due to errors", :mock_auth_api do
       login_with solicitor_user
-      click_link "Case Details for #{accepted_defence_request.dscc_number}"
+      click_link "Case details for #{accepted_defence_request.dscc_number}"
       click_link "Estimate time of arrival"
       enter_time date: "inv", hour: "a", min: "lid"
       click_button "Save"

--- a/spec/features/solicitor/view_aborted_requests_spec.rb
+++ b/spec/features/solicitor/view_aborted_requests_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Solicitors viewing aborted requests" do
   specify "can see 'aborted' defence requests", :mock_auth_api do
     login_with solicitor_user
     click_link "Closed"
-    click_link "Case Details for #{aborted_defence_request.dscc_number}"
+    click_link "Case details for #{aborted_defence_request.dscc_number}"
 
     expect(page).
       to have_content "This case has been aborted for the following reason"

--- a/spec/helpers/defence_requests_helper_spec.rb
+++ b/spec/helpers/defence_requests_helper_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe DefenceRequestsHelper, type: :helper do
 
-  describe "formatting not given field" do
-    context "when address is not given" do
-      context "i18n translation for not given is specified" do
+  describe "formatting Not given field" do
+    context "when address is Not given" do
+      context "i18n translation for Not given is specified" do
         it "returns the specified translation" do
           request = create(:defence_request)
           expect(helper.not_given_formatter(request, :detainee_address, "name_not_given")).to eq("Name not given")
@@ -12,9 +12,9 @@ RSpec.describe DefenceRequestsHelper, type: :helper do
       end
 
       context "i18n translation is not specified" do
-        it "returns 'not given'" do
+        it "returns 'Not given'" do
           request = create(:defence_request)
-          expect(helper.not_given_formatter(request, :detainee_address)).to eq("not given")
+          expect(helper.not_given_formatter(request, :detainee_address)).to eq("Not given")
         end
       end
     end
@@ -28,12 +28,12 @@ RSpec.describe DefenceRequestsHelper, type: :helper do
     end
   end
 
-  describe "formatting not given date" do
-    context "when date is not given" do
-      it "returns 'not given'" do
+  describe "formatting Not given date" do
+    context "when date is Not given" do
+      it "returns 'Not given'" do
         request = create(:defence_request)
         request.update(date_of_birth: nil)
-        expect(helper.date_not_given_formatter(request, :date_of_birth)).to eq("not given")
+        expect(helper.date_not_given_formatter(request, :date_of_birth)).to eq("Not given")
       end
     end
 

--- a/spec/support/features/defence_request_helpers.rb
+++ b/spec/support/features/defence_request_helpers.rb
@@ -54,7 +54,7 @@ module DefenceRequestHelpers
       end
     else
       within ".detainee" do
-        fill_in "Full Name", with: "Mannie Badder"
+        fill_in "Name", with: "Mannie Badder"
         choose options.fetch(:gender) { "Male" }
         fill_in "defence_request_date_of_birth_year", with: "1976"
         fill_in "defence_request_date_of_birth_month", with: "01"


### PR DESCRIPTION
- Reorders input elements on CSO form
- Updates label translations
- Changes "Not specified" gender option to "Unspecified"
- Adds ability to display help text for a specific date field