### PR TITLE
[clean_up_dotenv_files] removed unnecessary 'export' from the front of the .env files

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 # App settings
-export DISABLE_DASHBOARD_REFRESH=true
+DISABLE_DASHBOARD_REFRESH=true
 
 # Database settings
 DEFENCE_SOLICITOR_DATABASE_HOST=localhost

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 # App settings
-export DISABLE_DASHBOARD_REFRESH=true
+DISABLE_DASHBOARD_REFRESH=true
 
 # Database settings
 DEFENCE_SOLICITOR_DATABASE_HOST=localhost


### PR DESCRIPTION
Although the export clause is supported by dotenv, it's inconsistent.