### PR TITLE
tidy up broken field alignments in IE6/7

### DIFF
--- a/app/assets/javascripts/date_chooser.coffee
+++ b/app/assets/javascripts/date_chooser.coffee
@@ -34,7 +34,7 @@ class DateChooser
 
 
   enableLink: (selector) =>
-    selector.html("<a href>" + selector.text() + "</a>")
+    selector.html("<a href=\"#\">" + selector.text() + "</a>")
 
   toggleDate: (selector) =>
     selector.html selector.text()

--- a/app/assets/stylesheets/app-elements/forms/date-time-fields.scss
+++ b/app/assets/stylesheets/app-elements/forms/date-time-fields.scss
@@ -3,10 +3,6 @@
   margin-right: 1em;
 }
 
-.date-chooser-values {
-  display: inline-block;
-}
-
 .time-field-wrapper {
   display: inline-block;
   margin-right: 1em;

--- a/app/assets/stylesheets/ie6_overrides.scss
+++ b/app/assets/stylesheets/ie6_overrides.scss
@@ -41,3 +41,7 @@ dl.labels {
   padding-right: 0;
   width: 960px;
 }
+
+.date-field-wrapper {
+  float: left;
+}

--- a/app/assets/stylesheets/ie7_overrides.scss
+++ b/app/assets/stylesheets/ie7_overrides.scss
@@ -24,3 +24,7 @@ dl.labels {
   padding-right: 0;
   width: 960px;
 }
+
+.date-field-wrapper {
+  float: left;
+}

--- a/app/views/shared/_date_time_form_part.html.erb
+++ b/app/views/shared/_date_time_form_part.html.erb
@@ -25,15 +25,16 @@
         <%= t.text_field :min, size: 2, maxlength: 2, class: 'minute text-field' %>
       </div>
       <div class="date-field-wrapper">-</div>
-      <div class="date-chooser-values">
+      <div class="date-field-wrapper date-chooser-values">
         <label class="date-chooser-select form-label js-only" data-initial-date-index="<%= initial_date_index %>">
           <% dates.each do |date| %>
             <span class="date-chooser-link" data-date-display="<%= date.date.to_s :full %>"><%= t(date.name) %></span>
           <% end%>
         </label>
-        <div class="date-field-wrapper">
-          <%= t.text_field :date, class: "text-field date", value: date_formatter(date_value) %>
-        </div>
+        <!--[if IE 6]>
+        <%= t.label :date, t('date'), class: "form-label" %>
+        <![endif]-->
+        <%= t.text_field :date, class: "date text-field", value: date_formatter(date_value) %>
       </div>
     <% end %>
   </fieldset>


### PR DESCRIPTION
IE6 before: 
![ie6before](https://cloud.githubusercontent.com/assets/988436/8105432/05599dcc-1031-11e5-8e33-d83bd9b183c0.png)

IE6 after: 
![ie6after](https://cloud.githubusercontent.com/assets/988436/8105433/0bd6758a-1031-11e5-804a-5834186fc3f2.png)

IE7 before: 
![ie7before](https://cloud.githubusercontent.com/assets/988436/8105435/10e4fe98-1031-11e5-8830-28393db70d16.png)

IE7 after: 
![ie7after](https://cloud.githubusercontent.com/assets/988436/8105703/774bde20-1033-11e5-8547-456a87653fbc.png)




