### PR TITLE
[assets_on_s3] Ability to build assets on S3

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -30,6 +30,10 @@ SANDBOX_EMAIL_ADDRESS=iamadefencesolicitor@gmail.com
 # won't conflict with a real user's code
 GOOGLE_ANALYTICS_UA=UA-12345-1
 
+# AWS and S3 settings
+# You can only push to AWS buckets from EC2 instances in the correct IAM role:
+AWS_S3_ASSET_BUCKET_NAME=cannot_push_to_aws_bucket_from_local_machine
+
 # Authentication setting
 AUTHENTICATION_SITE_URL=http://localhost:45454
 AUTHENTICATION_REDIRECT_URI=http://localhost:12121/auth/defence_request/callback

--- a/.env.test
+++ b/.env.test
@@ -27,6 +27,10 @@ SANDBOX_EMAIL_ADDRESS=iamadefencesolicitor@gmail.com
 # won't conflict with a real user's code
 GOOGLE_ANALYTICS_UA=UA-12345-1
 
+# AWS and S3 settings
+# You can only push to AWS buckets from EC2 instances in the correct IAM role:
+AWS_S3_ASSET_BUCKET_NAME=cannot_push_to_aws_bucket_from_local_machine
+
 # Authentication setting
 AUTHENTICATION_SITE_URL="http://app.example.com/site"
 AUTHENTICATION_REDIRECT_URI="http://app.example.com/redirect"

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem "govuk_elements_rails", "~> 0.3.0"
 # Font Awesome 3.x to support IE7
 gem "font-awesome-rails", "3.2.1.3"
 
+# Asset sync - for uploading assets to S3
+gem "asset_sync"
+
 group :development do
   gem "guard-rspec", require: false
   gem "web-console", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.3.1)
     actionmailer (4.2.1)
       actionpack (= 4.2.1)
       actionview (= 4.2.1)
@@ -69,6 +70,10 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.7)
     arel (6.0.0)
+    asset_sync (1.1.0)
+      activemodel
+      fog (>= 1.8.0)
+      unf
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
@@ -116,6 +121,7 @@ GEM
     dotenv-rails (2.0.0)
       dotenv (= 2.0.0)
     erubis (2.7.0)
+    excon (0.45.3)
     execjs (2.3.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -127,6 +133,102 @@ GEM
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.6)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.31.0)
+      fog-atmos
+      fog-aws (~> 0.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.30)
+      fog-ecloud
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.4.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.7.1)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.30.0)
+      builder
+      excon (~> 0.45)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-ecloud (0.1.3)
+      fog-core
+      fog-xml
+    fog-google (0.0.5)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.3)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.4)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.0.1)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.6)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     font-awesome-rails (3.2.1.3)
       railties (>= 3.2, < 5.0)
     formatador (0.2.5)
@@ -161,6 +263,8 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
+    inflecto (0.0.2)
+    ipaddress (0.8.0)
     jasmine (2.0.3)
       jasmine-core (~> 2.0.0)
       phantomjs
@@ -209,6 +313,9 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.2.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     notiffany (0.0.5)
@@ -355,6 +462,9 @@ GEM
     uglifier (2.7.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -377,6 +487,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  asset_sync
   audited-activerecord (~> 4.0.0)
   awesome_print
   byebug
@@ -430,4 +541,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.2
+   1.10.3

--- a/config/initializers/asset_sync.rb
+++ b/config/initializers/asset_sync.rb
@@ -1,0 +1,21 @@
+# To compile assets and push them to S3, run "bundle exec rake assets:sync".
+# Note that this will only work from an AWS instance that is part of the
+# correct IAM role.
+AssetSync.configure do |config|
+  config.fog_provider = "AWS"
+
+  # We use Instance roles rather than specifying an AWS access Key and secret
+  config.aws_iam_roles = true
+
+  # We don't want to sync every time we precompile assets - only on-demand
+  config.run_on_precompile = false
+
+  # Bucket name
+  config.fog_directory = Settings.aws.s3_asset_bucket_name
+
+  # Increase upload performance by configuring your region
+  config.fog_region = Settings.aws.region
+
+  # Don't delete files from the store
+  config.existing_remote_files = "keep"
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,3 +32,7 @@ authentication:
 
 analytics:
   google_ua: <%= ENV.fetch("GOOGLE_ANALYTICS_UA", nil) %>
+
+aws:
+  region: eu-west-1
+  s3_asset_bucket_name: <%= ENV.fetch("AWS_S3_ASSET_BUCKET_NAME") %>


### PR DESCRIPTION
On an AWS instance that's correctly part of the right instance group,
you can now push assets to an S3 bucket with the command
"bundle exec rake assets:sync"

- Added asset_sync gem
- Added config for asset_sync that allows for discovery of the server's
  instance permissions, so that it can communicate with the correct
  S3 bucket
- Added a new section to the settings.yml file for AWS-related things.
- Set default values for the different environments.