### PR TITLE
Improve policy for creating / editing requests by cso

### DIFF
--- a/app/controllers/concerns/defence_request_concern.rb
+++ b/app/controllers/concerns/defence_request_concern.rb
@@ -10,12 +10,8 @@ module DefenceRequestConcern
     @defence_request ||= DefenceRequestFactory.build(current_user)
   end
 
-  def new_defence_request_form
-    @defence_request_form ||= DefenceRequestForm.new(defence_request)
-  end
-
-  def authorize_defence_request_access(action)
-    policy_context = PolicyContext.new(defence_request, current_user)
+  def authorize_defence_request_access(action, request_to_authorize = defence_request)
+    policy_context = PolicyContext.new(request_to_authorize, current_user)
     @policy ||= policy(policy_context)
     authorize policy_context, "#{action}?"
   end

--- a/app/controllers/defence_requests_controller.rb
+++ b/app/controllers/defence_requests_controller.rb
@@ -3,14 +3,15 @@ class DefenceRequestsController < BaseController
   include DefenceRequestConcern
 
   before_action :find_defence_request, except: [:new, :create]
-  before_action :new_defence_request_form, only: [:show, :new, :create, :edit, :update]
 
   before_action ->(c) { authorize_defence_request_access(c.action_name) }
 
   helper_method :defence_request_path_with_tab
 
   def show
+    @defence_request_form = DefenceRequestForm.new(defence_request)
     @tab = tab_param_value(:tab)
+
     if @defence_request.draft?
       render :show_draft
     else
@@ -19,10 +20,13 @@ class DefenceRequestsController < BaseController
   end
 
   def new
+    @defence_request_form = DefenceRequestForm.new(defence_request)
   end
 
   def create
-    if @defence_request_form.submit(defence_request_params)
+    @defence_request_form = DefenceRequestForm.new(defence_request, defence_request_params)
+
+    if @defence_request_form.submit
       redirect_to(@defence_request_form.defence_request, notice: flash_message(:create, DefenceRequestForm))
     else
       render :new
@@ -30,13 +34,17 @@ class DefenceRequestsController < BaseController
   end
 
   def edit
+    @defence_request_form = DefenceRequestForm.new(defence_request)
     @part = tab_param_value(:part)
+
     render edit_template
   end
 
   def update
+    @defence_request_form = DefenceRequestForm.new(defence_request, defence_request_params)
     @part = tab_param_value(:part)
-    if @defence_request_form.submit(defence_request_params)
+
+    if @defence_request_form.submit
       redirect_to(defence_request_path_with_tab(@part), notice: flash_message(:update, DefenceRequest))
     else
       render edit_template

--- a/app/controllers/defence_requests_controller.rb
+++ b/app/controllers/defence_requests_controller.rb
@@ -4,7 +4,7 @@ class DefenceRequestsController < BaseController
 
   before_action :find_defence_request, except: [:new, :create]
 
-  before_action ->(c) { authorize_defence_request_access(c.action_name) }
+  before_action :authorise_action_access, except: [:create, :update]
 
   helper_method :defence_request_path_with_tab
 
@@ -26,6 +26,8 @@ class DefenceRequestsController < BaseController
   def create
     @defence_request_form = DefenceRequestForm.new(defence_request, defence_request_params)
 
+    authorize_defence_request_access(:create, @defence_request_form.defence_request)
+
     if @defence_request_form.submit
       redirect_to(@defence_request_form.defence_request, notice: flash_message(:create, DefenceRequestForm))
     else
@@ -44,6 +46,8 @@ class DefenceRequestsController < BaseController
     @defence_request_form = DefenceRequestForm.new(defence_request, defence_request_params)
     @part = tab_param_value(:part)
 
+    authorize_defence_request_access(:edit, @defence_request_form.defence_request)
+
     if @defence_request_form.submit
       redirect_to(defence_request_path_with_tab(@part), notice: flash_message(:update, DefenceRequest))
     else
@@ -60,6 +64,10 @@ class DefenceRequestsController < BaseController
   end
 
   private
+
+  def authorise_action_access
+    authorize_defence_request_access(action_name)
+  end
 
   def defence_request_id
     :id

--- a/app/controllers/interview_start_times_controller.rb
+++ b/app/controllers/interview_start_times_controller.rb
@@ -4,16 +4,19 @@ class InterviewStartTimesController < BaseController
   include AjaxEnabledConcern
 
   before_action :find_defence_request
-  before_action :new_defence_request_form
 
   before_action ->(c) { authorize_defence_request_access(:interview_start_time_edit) }
 
   def edit
+    @defence_request_form = DefenceRequestForm.new(defence_request)
+
     render_for_ajax_or_page(:_form, :edit)
   end
 
   def update
-    if @defence_request_form.submit(defence_request_params)
+    @defence_request_form = DefenceRequestForm.new(defence_request, defence_request_params)
+
+    if @defence_request_form.submit
       redirect_params = { notice: flash_message(:interview_start_time, DefenceRequest) }
       render_for_ajax_or_redirect(:_interview_time, defence_request_path(@defence_request), redirect_params)
     else

--- a/app/forms/defence_request_form.rb
+++ b/app/forms/defence_request_form.rb
@@ -35,15 +35,21 @@ class DefenceRequestForm
     register_field :interview_start_time, DateTimeField
   end
 
-  def error_message_lookup_proc(field_name)
-    @defence_request.errors.method(:generate_message).curry(2)[field_name]
-  end
-
-  def register_field(field_name, klass, opts={})
-    @fields[field_name] = klass.from_persisted_value @defence_request.send field_name
-  end
-
   def submit(params)
+    assign_params(params)
+
+    if valid?
+      @defence_request.save!
+      true
+    else
+      add_errors_to_form
+      false
+    end
+  end
+
+  private
+
+  def assign_params(params)
     @fields.select!{ |k, v| params.include?(k) }
 
     params_without_fields = params.reject { |k, _| @fields.keys.include? k.to_sym }
@@ -55,14 +61,18 @@ class DefenceRequestForm
       @fields[field_name] = field_value
       @defence_request.assign_attributes({ field_name => field_value.value })
     end
+  end
 
-    if @fields.all?(&valid_if_present?) & @defence_request.valid?
-      @defence_request.save!
-      true
-    else
-      add_errors_to_form
-      false
-    end
+  def valid?
+    @fields.all?(&valid_if_present?) & @defence_request.valid?
+  end
+
+  def error_message_lookup_proc(field_name)
+    @defence_request.errors.method(:generate_message).curry(2)[field_name]
+  end
+
+  def register_field(field_name, klass, opts={})
+    @fields[field_name] = klass.from_persisted_value @defence_request.send field_name
   end
 
   def add_errors_to_form

--- a/app/forms/defence_request_form.rb
+++ b/app/forms/defence_request_form.rb
@@ -25,7 +25,7 @@ class DefenceRequestForm
     ActiveModel::Name.new(self, nil, "DefenceRequest")
   end
 
-  def initialize(defence_request)
+  def initialize(defence_request, params = {})
     @fields = {}
     @defence_request = defence_request
     register_field :date_of_birth, DateField
@@ -33,11 +33,11 @@ class DefenceRequestForm
     register_field :time_of_arrest, DateTimeField
     register_field :time_of_detention_authorised, DateTimeField
     register_field :interview_start_time, DateTimeField
+
+    assign_params(params) unless params.empty?
   end
 
-  def submit(params)
-    assign_params(params)
-
+  def submit
     if valid?
       @defence_request.save!
       true

--- a/app/policies/cso_defence_request_policy.rb
+++ b/app/policies/cso_defence_request_policy.rb
@@ -28,7 +28,7 @@ class CsoDefenceRequestPolicy < ApplicationPolicy
   end
 
   def create?
-    true
+    belongs_to_custody_suite?
   end
 
   def edit?

--- a/app/views/dashboards/_dashboard.html.erb
+++ b/app/views/dashboards/_dashboard.html.erb
@@ -4,7 +4,7 @@
 
 <%= flash_messages %>
 
-<% if check_policy_clause(@policy, :create?) %>
+<% if check_policy_clause(@policy, :new?) %>
   <div class="new_defence_request">
     <%= link_to t("new_request"), new_defence_request_path, role: "button", class: "button" %>
   </div>

--- a/spec/features/cso/creating_defence_request_spec.rb
+++ b/spec/features/cso/creating_defence_request_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Custody Suite Officers creating defence requests" do
-  specify "creating a blank defence request displays all required validation errors" do
+  specify "creating a blank defence request displays all required validation errors", focus: true do
     login_and_open_new_defence_request_page
 
     click_button "Create request"

--- a/spec/forms/defence_request_form_spec.rb
+++ b/spec/forms/defence_request_form_spec.rb
@@ -3,37 +3,59 @@ require "rails_helper"
 RSpec.describe DefenceRequestForm do
 
   let (:defence_request) { FactoryGirl.create(:defence_request) }
-  subject { DefenceRequestForm.new FactoryGirl.create(:defence_request) }
+  let (:params_for_dr) do
+    defence_request_params = FactoryGirl.attributes_for(:defence_request)
 
-  let (:params_for_dr)   { {  detainee_name: defence_request.detainee_name,
-                              gender: defence_request.gender,
-                              offences: defence_request.offences,
-                              time_of_arrival: datetime_to_params(defence_request.time_of_arrival),
-                              comments: defence_request.comments } }
+    {
+      detainee_name: defence_request_params[:detainee_name],
+      gender: defence_request_params[:gender],
+      offences: defence_request_params[:offences],
+      time_of_arrival: datetime_to_params(defence_request_params[:time_of_arrival]),
+      comments: defence_request_params[:comments]
+    }
+  end
+  let(:params) { {} }
 
+  subject(:form) { described_class.new(defence_request, params) }
+
+  describe "#initialize" do
+    context "with params" do
+      let(:params) { params_for_dr }
+
+      it "assigns the params to the defence request" do
+        expect(subject.defence_request.detainee_name).to eql(params[:detainee_name])
+      end
+    end
+  end
 
   describe "submit" do
+    subject { form.submit }
+
     context "with valid params" do
+      let(:params) { params_for_dr }
+
       it "returns true, and has no errors" do
-        expect(subject.submit params_for_dr).to eql true
-        expect(subject.errors).to be_blank
+        is_expected.to be true
+        expect(form.errors).to be_blank
       end
     end
 
     context "with invalid params" do
       context "invalid attribute on the dr" do
-        let(:invalid_params) { params_for_dr.merge({ gender: "" }) }
+        let(:params) { params_for_dr.merge({ gender: "" }) }
 
         it "adds any errors from the dr, to itself" do
-          expect(subject.submit invalid_params).to eql false
-          expect(subject.errors.count).to eql 1
-          expect(subject.errors[:gender]).to contain_exactly("You must describe the detainee's gender or select 'Unspecified'")
+          is_expected.to be false
+
+          expect(form.errors.count).to eql 1
+          expect(form.errors[:gender]).to contain_exactly("You must describe the detainee's gender or select 'Unspecified'")
         end
       end
 
       context "invalid field object" do
         context "that is has presence validated on the dr" do
-          let(:invalid_params) { params_for_dr.merge({ time_of_arrival: invalid_time_of_arrival }) }
+          let(:params) { params_for_dr.merge({ time_of_arrival: invalid_time_of_arrival }) }
+
           context "blank" do
             let(:invalid_time_of_arrival) { { date: "",
                                               hour: "",
@@ -43,9 +65,10 @@ RSpec.describe DefenceRequestForm do
             }
 
             it "adds errors from the field object to itself" do
-              expect(subject.submit invalid_params).to eql false
-              expect(subject.errors.count).to eql 1
-              expect(subject.errors[:time_of_arrival]).to contain_exactly expected_error_message
+              is_expected.to be false
+
+              expect(form.errors.count).to eql 1
+              expect(form.errors[:time_of_arrival]).to contain_exactly expected_error_message
             end
           end
 
@@ -58,15 +81,16 @@ RSpec.describe DefenceRequestForm do
             }
 
             it "adds errors from the field object to itself" do
-              expect(subject.submit invalid_params).to eql false
-              expect(subject.errors.count).to eql 1
-              expect(subject.errors[:time_of_arrival]).to contain_exactly expected_error_message
+              is_expected.to be false
+
+              expect(form.errors.count).to eql 1
+              expect(form.errors[:time_of_arrival]).to contain_exactly expected_error_message
             end
           end
         end
 
         context "that does not have presence validated on the dr" do
-          let(:invalid_params) { params_for_dr.merge({ interview_start_time: invalid_interview_start_time }) }
+          let(:params) { params_for_dr.merge({ interview_start_time: invalid_interview_start_time }) }
 
           context "blank" do
             let(:invalid_interview_start_time) { { date: "",
@@ -75,8 +99,9 @@ RSpec.describe DefenceRequestForm do
 
 
             it "it does not add any errors to itself" do
-              expect(subject.submit invalid_params).to eql true
-              expect(subject.errors.count).to eql 0
+              is_expected.to be true
+
+              expect(form.errors.count).to eql 0
             end
           end
 
@@ -89,9 +114,11 @@ RSpec.describe DefenceRequestForm do
             }
 
             it "adds errors from the field object to itself" do
-              expect(subject.submit invalid_params).to eql false
-              expect(subject.errors.count).to eql 1
-              expect(subject.errors[:interview_start_time]).to contain_exactly expected_error_message
+              is_expected.to be false
+
+
+              expect(form.errors.count).to eql 1
+              expect(form.errors[:interview_start_time]).to contain_exactly expected_error_message
             end
           end
         end

--- a/spec/policies/cso_defence_request_policy_spec.rb
+++ b/spec/policies/cso_defence_request_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CsoDefenceRequestPolicy do
 
   context "with request not assigned to the same custody suite" do
     let(:defence_request) { build(:defence_request) }
-    let(:allowed_actions) { [:new, :create] }
+    let(:allowed_actions) { [:new] }
 
     it { is_expected.to permit_actions_and_forbid_all_others(allowed_actions) }
   end


### PR DESCRIPTION
The policy now checks the action with the changed object. So a cso user can't assign (re-assign) the defence request to another custody suite. 

I've done a bit of a cleanup, but I'd like to do more. In `DefenceRequestController` I've removed one of the `before_action` filters, which was creating the form. But I would like to take it further and remove at least the `find_defence_request` filter and maybe even the authorisation one. Because it's now very unclear which instance of `DefenceRequest` is actually assigned to `@defence_request`. For example for `edit` and `update`, we actually use `DefenceRequestPresenter`. Which is not right.