### PR TITLE
CSO can make changes to defence requests raised by the same custody suite

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -39,6 +39,10 @@ FactoryGirl.define do
   factory :cso_user, class: ServiceUser do
     to_create { |instance| instance }
 
+    transient do
+      organisation { build(:organisation, :custody_suite) }
+    end
+
     initialize_with {
       omni_auth_user = Omniauth::Dsds::User.new(
         uid: SecureRandom.uuid,
@@ -46,9 +50,9 @@ FactoryGirl.define do
         email: "cso_user@example.com",
         organisations: [
           {
-            "uid" => SecureRandom.uuid,
-            "name" => "Example custody suite",
-            "type" => "custody_suite",
+            "uid" => organisation.uid,
+            "name" => organisation.name,
+            "type" => organisation.type,
             "roles" => ["cso"]
           }
         ]

--- a/spec/features/cso/editing_defence_request_spec.rb
+++ b/spec/features/cso/editing_defence_request_spec.rb
@@ -2,36 +2,41 @@ require "rails_helper"
 
 RSpec.feature "Custody Suite Officers editing defence requests" do
 
-  specify "can edit detainee details" do
-    login_and_view_defence_request
+  context "for defence requests assigned to the same custody suite" do
+    specify "can edit detainee details" do
+      login_and_view_defence_request
 
-    within ".detainee-details" do
-      click_link "Change this"
+      within ".detainee-details" do
+        click_link "Change this"
+      end
+
+      fill_in "defence_request_detainee_address", with: "Changed address"
+      click_button "Save changes"
+
+      expect(page).to have_content("Changed address")
     end
 
-    fill_in "defence_request_detainee_address", with: "Changed address"
-    click_button "Save changes"
+    specify "can edit case details" do
+      login_and_view_defence_request
 
-    expect(page).to have_content("Changed address")
-  end
+      click_link "Case details"
+      within ".case-details" do
+        click_link "Change this"
+      end
 
-  specify "can edit case details" do
-    login_and_view_defence_request
+      fill_in "defence_request_custody_number", with: "New number"
+      click_button "Save changes"
 
-    click_link "Case details"
-    within ".case-details" do
-      click_link "Change this"
+      expect(page).to have_content("New number")
     end
-
-    fill_in "defence_request_custody_number", with: "New number"
-    click_button "Save changes"
-
-    expect(page).to have_content("New number")
   end
 
   def login_and_view_defence_request
-    cso = create :cso_user
-    defence_request = create :defence_request, :queued, custody_suite_uid: cso.organisation["uid"]
+    custody_suite = build :organisation, :custody_suite
+
+    defence_request = create :defence_request, :queued, custody_suite_uid: custody_suite.uid
+
+    cso = create :cso_user, organisation: custody_suite
 
     login_as_cso(cso)
 


### PR DESCRIPTION
The actual implementation has already been done, so I've only changed the current test to verify this works.