### PR TITLE
[asset_content_encoding] Revert to known-good fog-aws version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "coffee-rails", "~> 4.1.0"
 gem "chronic"
 gem "drs-auth_client", github: "ministryofjustice/defence-request-service-auth", tag: "v0.2.1"
 gem "faker", "~> 1.4.3"
+gem "fog-aws", "= 0.1.2"          # See https://github.com/fog/fog-aws/issues/130
 gem "httparty", "~> 0.13.3"
 gem "jbuilder", "~> 2.0"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.4.0)
+    fog-aws (0.1.2)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -170,7 +170,7 @@ GEM
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.30.0)
+    fog-core (1.31.1)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
@@ -309,7 +309,7 @@ GEM
     minitest (5.7.0)
     moj_template (0.23.0)
       rails (>= 3.1)
-    multi_json (1.11.0)
+    multi_json (1.11.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.2.0)
@@ -501,6 +501,7 @@ DEPENDENCIES
   drs-auth_client!
   factory_girl_rails
   faker (~> 1.4.3)
+  fog-aws (= 0.1.2)
   font-awesome-rails (= 3.2.1.3)
   govuk_elements_rails (~> 0.3.0)
   govuk_frontend_toolkit (~> 3.4.2)


### PR DESCRIPTION
The asset_sync gem uses fog-aws to upload assets to S3. However fog-aws > 0.1.2 sets the Content-Encoding to null value.

This gem can be removed once https://github.com/fog/fog-aws/issues/130 is correctly resolved